### PR TITLE
feat(contracts): engine pin, surface registry, fail-closed validator, CI (U4/U1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  surface-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
+      - name: Surface registry gate (fail-closed)
+        run: python scripts/validate_surfaces.py
+      - name: Validator unit tests (green on good, red on tampered)
+        run: python -m unittest discover -s scripts -p "test_*.py" -v

--- a/contracts/engine-pin.yaml
+++ b/contracts/engine-pin.yaml
@@ -1,0 +1,14 @@
+# Engine contract pin — marvis consumes the governed marvisx contract.
+# Separation goal 2026-07-24, U4: marvis is a versioned consumer, no longer a
+# force-mirrored branch copy (the destructive mirror was retired upstream in
+# marvisx PR #176). This tree still derives from the last mirror sync
+# (marvisx @ 56e0b286); from here on, engine updates arrive as explicit,
+# reviewed changes against the pinned contract below.
+# Source of truth: marvisx:contracts/openapi/VERSION (profile all-surfaces,
+# breaking gate hard-fail, compatibility window N/N-1).
+engine: marvisx
+contract_version: 1
+engine_ref: c02ee4adba4d5130be4ae6beeb43220c28986bde
+openapi_baseline: marvisx:contracts/openapi/marvisx.json
+compatibility_window: N/N-1
+mirror_lineage: 56e0b286

--- a/contracts/surfaces/desktop-ui.yaml
+++ b/contracts/surfaces/desktop-ui.yaml
@@ -1,0 +1,26 @@
+# Surface manifest — future desktop/local GUI owned by marvis (U7/U8). STUB,
+# fail-closed: declared so the registry can tell this surface apart from the
+# CLI wheel and from foreign product GUIs, but NOT deployable. Flipping
+# deployable requires proof for every prerequisite below. No desktop framework
+# is named here — that choice belongs to a separate ADR (plan KTD4).
+surface_id: desktop-ui
+owner_project: marvis
+owner_repo: emiliomartucci/marvis
+contract_version: 1
+description: >-
+  Desktop/local GUI for the marvis product. Owned by marvis; never built from
+  or served by marvisx UI bundles (KTD10), never a Cloud or terminal surface.
+
+deployable: false
+
+# U7/U8 gate — each key must map to non-empty evidence before deployable may
+# become true. The validator enforces this shape.
+prerequisites:
+  local_gui_characterization: null
+  desktop_host_contract: null
+  shell_adr_decision: null
+
+forbidden_sources:
+  - marvisx:core/console
+forbidden_targets:
+  - console.justaskmarvis.com/terminal/

--- a/contracts/surfaces/marvis-cli.yaml
+++ b/contracts/surfaces/marvis-cli.yaml
@@ -1,0 +1,25 @@
+# Surface manifest — public marvis-cli product (CLI + local MCP + runtime).
+# Consumed by scripts/validate_surfaces.py in CI. Same registry pattern as
+# marvisx:contracts/surfaces/terminal-console.yaml and
+# marvisx-cloud:contracts/surfaces/cloud-edge.yaml (U1 portfolio, separation
+# goal 2026-07-24).
+surface_id: marvis-cli
+owner_project: marvis
+owner_repo: emiliomartucci/marvis
+contract_version: 1
+description: >-
+  Public OSS/open-core product: CLI, local MCP server and local runtime,
+  shipped as a Python wheel.
+
+artifact_kind: python-wheel
+# Compatibility distribution name during migration (plan naming registry); a
+# public rename is a separately planned decision. Cross-checked against
+# pyproject.toml by the validator.
+distribution_name: marvisx-cli
+
+deploy:
+  tool: github-release
+  workflow: .github/workflows/release.yml
+  trigger: v* tag, human-gated pypi environment
+rollback:
+  strategy: pip-version-pin

--- a/scripts/test_validate_surfaces.py
+++ b/scripts/test_validate_surfaces.py
@@ -1,0 +1,79 @@
+"""The gate must be proven RED on broken inputs, not only green on good ones
+(marvisx learning d3b7f373: a gate never seen failing proves nothing)."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from validate_surfaces import validate  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class FixtureCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dir = Path(tempfile.mkdtemp(prefix="surfaces-"))
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        shutil.copytree(REPO_ROOT / "contracts", self.dir / "contracts")
+        shutil.copy(REPO_ROOT / "pyproject.toml", self.dir / "pyproject.toml")
+
+    def rewrite(self, rel: str, old: str, new: str) -> None:
+        path = self.dir / rel
+        path.write_text(path.read_text(encoding="utf-8").replace(old, new), encoding="utf-8")
+
+
+class TestValidator(FixtureCase):
+    def test_real_repo_state_is_green(self) -> None:
+        self.assertEqual(validate(REPO_ROOT), [])
+
+    def test_red_wrong_distribution_name(self) -> None:
+        self.rewrite(
+            "contracts/surfaces/marvis-cli.yaml",
+            "distribution_name: marvisx-cli",
+            "distribution_name: some-other-wheel",
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("distribution_name" in e for e in errors), errors)
+
+    def test_red_foreign_hostname_claim(self) -> None:
+        self.rewrite(
+            "contracts/surfaces/marvis-cli.yaml",
+            "artifact_kind: python-wheel",
+            "artifact_kind: python-wheel\nallowed_hostnames:\n  - console.justaskmarvis.com",
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("owned by another product" in e for e in errors), errors)
+
+    def test_red_desktop_ui_flipped_without_proof(self) -> None:
+        self.rewrite(
+            "contracts/surfaces/desktop-ui.yaml", "deployable: false", "deployable: true"
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("prerequisites without proof" in e for e in errors), errors)
+
+    def test_red_wrong_owner_project(self) -> None:
+        self.rewrite(
+            "contracts/surfaces/marvis-cli.yaml",
+            "owner_project: marvis",
+            "owner_project: marvisx",
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("owner_project" in e for e in errors), errors)
+
+    def test_red_tampered_engine_pin(self) -> None:
+        self.rewrite(
+            "contracts/engine-pin.yaml",
+            "engine_ref: c02ee4adba4d5130be4ae6beeb43220c28986bde",
+            "engine_ref: not-a-sha",
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("engine_ref" in e for e in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_surfaces.py
+++ b/scripts/validate_surfaces.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Fail-closed surface registry validator for the marvis product repo.
+
+U1 portfolio registry / U4 consumer slice of the separation goal
+(marvisx:docs/goals/2026-07-24-separate-surfaces.md). Runs in CI before any
+build or release step; a non-empty error list means nothing may ship.
+
+Incident lineage: a generic Console artifact once shipped the wrong UI contract
+to another product's surface behind a green CI (marvisx postmortem 2026-07-24).
+This registry exists so an owner/target mismatch fails BEFORE any artifact is
+built.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+OWNER_PROJECT = "marvis"
+OWNER_REPO = "emiliomartucci/marvis"
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+REQUIRED_FIELDS = ("surface_id", "owner_project", "owner_repo", "contract_version", "description")
+# Hostnames owned by other products in the portfolio; no manifest here may claim them.
+FOREIGN_HOSTNAMES = {
+    "console.justaskmarvis.com",
+    "emilio.cloud.justaskmarvis.com",
+    "cloud.justaskmarvis.com",
+    "t.justaskmarvis.com",
+    "app.justaskmarvis.com",
+    "api.justaskmarvis.com",
+}
+
+
+def pyproject_distribution_name(root: Path) -> str | None:
+    text = (root / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^name\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def validate(root: Path) -> list[str]:
+    errors: list[str] = []
+    surfaces_dir = root / "contracts" / "surfaces"
+    if not surfaces_dir.is_dir():
+        return [f"missing {surfaces_dir} — registry is absent"]
+
+    manifests = {}
+    for path in sorted(surfaces_dir.glob("*.yaml")):
+        where = f"contracts/surfaces/{path.name}"
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(doc, dict):
+            errors.append(f"{where}: not a mapping")
+            continue
+        for field in REQUIRED_FIELDS:
+            if not doc.get(field) and doc.get(field) != 0:
+                errors.append(f"{where}: missing required field {field}")
+        sid = doc.get("surface_id")
+        if sid in manifests:
+            errors.append(f"{where}: duplicate surface_id {sid}")
+        manifests[sid] = doc
+        if doc.get("owner_project") and doc["owner_project"] != OWNER_PROJECT:
+            errors.append(f"{where}: owner_project {doc['owner_project']} != {OWNER_PROJECT}")
+        if doc.get("owner_repo") and doc["owner_repo"] != OWNER_REPO:
+            errors.append(f"{where}: owner_repo {doc['owner_repo']} != {OWNER_REPO}")
+        if "contract_version" in doc and not isinstance(doc["contract_version"], int):
+            errors.append(f"{where}: contract_version must be an integer")
+        for host in doc.get("allowed_hostnames") or []:
+            if host in FOREIGN_HOSTNAMES:
+                errors.append(f"{where}: hostname {host} is owned by another product")
+
+    cli = manifests.get("marvis-cli")
+    if cli is None:
+        errors.append("marvis-cli manifest missing — the shipped wheel would be unregistered")
+    else:
+        real_name = pyproject_distribution_name(root)
+        declared = cli.get("distribution_name")
+        if real_name and declared and real_name != declared:
+            errors.append(
+                f"marvis-cli: distribution_name {declared} != pyproject.toml name {real_name}"
+            )
+
+    desktop = manifests.get("desktop-ui")
+    if desktop is None:
+        errors.append("desktop-ui manifest missing — the future GUI surface must stay declared")
+    elif desktop.get("deployable") is True:
+        prereqs = desktop.get("prerequisites") or {}
+        unproven = [key for key, value in prereqs.items() if value in (None, "")]
+        if not prereqs:
+            errors.append("desktop-ui: deployable=true with no prerequisites declared")
+        if unproven:
+            errors.append(
+                "desktop-ui: deployable=true but prerequisites without proof: " + ", ".join(unproven)
+            )
+
+    pin_path = root / "contracts" / "engine-pin.yaml"
+    try:
+        pin = yaml.safe_load(pin_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        errors.append(f"cannot read contracts/engine-pin.yaml: {exc}")
+    else:
+        if not isinstance(pin, dict) or pin.get("engine") != "marvisx":
+            errors.append("engine-pin: engine must be marvisx")
+        if not isinstance((pin or {}).get("contract_version"), int):
+            errors.append("engine-pin: contract_version must be an integer")
+        if not SHA_RE.match(str((pin or {}).get("engine_ref", ""))):
+            errors.append("engine-pin: engine_ref must be a 40-hex commit SHA")
+
+    return errors
+
+
+def main() -> int:
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    errors = validate(root)
+    if errors:
+        print("surface registry INVALID:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(
+        "surface registry valid: marvis-cli matches pyproject.toml, "
+        "desktop-ui is fail-closed, engine pin ok"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
U4 versioned-consumer slice + U1 portfolio registry for the public product repo (separation goal `marvisx:docs/goals/2026-07-24-separate-surfaces.md`). Part of the authorized PR-only autonomous run. Additive; no PyPI publish, no `v*` tag, no GUI source move.

## What
- `contracts/engine-pin.yaml` — **marvis becomes a pinned consumer** of the governed marvisx contract (`contract_version 1` @ `c02ee4ad`, N/N-1 window). The mirror lineage fact is recorded: this tree derives from the last force-mirror sync (marvisx @ `56e0b286`); the destructive mirror was retired upstream (marvisx #176), so engine updates now arrive as explicit reviewed changes.
- `contracts/surfaces/marvis-cli.yaml` — manifest of the **real product surface**: the python wheel (`marvisx-cli`, compatibility distribution name per the plan's naming registry), cross-checked against `pyproject.toml` by the validator. Release stays behind the human-gated `v*` tag flow.
- `contracts/surfaces/desktop-ui.yaml` — fail-closed **stub** for the future desktop GUI (U7/U8): `deployable: false` until local-GUI characterization, the desktop host contract and the separate shell ADR carry proof. **No desktop framework is named** (plan KTD4).
- `scripts/validate_surfaces.py` (+ unit tests) — registry gate proven **green on the real tree and RED on five tampered fixtures** (wrong distribution name, foreign-product hostname, unproven deployable flip, wrong owner, invalid engine pin — per learning `d3b7f373`).
- `.github/workflows/ci.yml` — first general CI for this repo: registry gate + validator tests.

## Registry status after merge
3 of 4 products carry surface manifests + fail-closed validators (marvisx ✔, marvisx-cloud ✔, marvis this PR); marvis-enterprise follows in its own PR.

Task: 23cc2ce4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvo6XZohWoMG9nKfZVFp3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvo6XZohWoMG9nKfZVFp3Q)_