### PR TITLE
feat(desktop-ui): build the local GUI from its declared perimeter only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,23 +32,48 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Prune the build tree to the local perimeter
+        # The wheel must carry only what the local product owns. Without this
+        # the export is the whole app: terminal, hosted administration and
+        # SaaS routes ship inside the local release and answer direct URLs.
+        # The script refuses to run if apps/desktop-ui/surfaces.yaml and the
+        # source have drifted, so a stale perimeter cannot produce an artifact.
+        run: |
+          set -euo pipefail
+          python -m pip install --quiet pyyaml
+          python scripts/build_local_gui.py build/local-gui
+
       - name: Build Console static export in Docker
         run: |
           set -euo pipefail
           docker run --rm \
             -v "$PWD:/repo" \
-            -w /repo/core/console \
+            -w /repo/build/local-gui \
             -e NEXT_PUBLIC_API_URL="" \
             -e NEXT_PUBLIC_LOCAL_MODE=1 \
             -e NEXT_TELEMETRY_DISABLED=1 \
             node:22-bookworm \
             bash -lc 'npm ci && npm run build'
 
-          test -f core/console/out/index.html
-          test -d core/console/out/_next
+          test -f build/local-gui/out/index.html
+          test -d build/local-gui/out/_next
           rm -rf core/api/console_dist
           mkdir -p core/api/console_dist
-          cp -a core/console/out/. core/api/console_dist/
+          cp -a build/local-gui/out/. core/api/console_dist/
+
+      - name: Fail if a foreign surface reached the local artifact
+        # Proving the export, not the intent: a route outside the perimeter in
+        # the shipped bundle is the 2026-07-23 incident shape (one artifact
+        # serving several products).
+        run: |
+          set -euo pipefail
+          for route in terminal settings monitoring brain graph inbox triage finder; do
+            if find core/api/console_dist -path "*/$route/*" -name "*.html" | grep -q .; then
+              echo "::error::/$route/ is not owned by the local product but reached the artifact"
+              exit 1
+            fi
+          done
+          echo "artifact carries the local perimeter only"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/scripts/build_local_gui.py
+++ b/scripts/build_local_gui.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Prepare the local GUI build tree from its declared perimeter (U7).
+
+The local product ships a Next static export. Today that export is the whole
+application, so routes owned by other products — the terminal, hosted
+administration, SaaS surfaces — travel inside the local wheel and answer to a
+direct URL even though navigation hides them.
+
+This prunes a copy of the console source down to the perimeter declared in
+apps/desktop-ui/surfaces.yaml before the build runs, so the artifact can only
+contain what the local product owns. The source tree is never modified: the
+pruning happens in a build directory.
+
+Usage:
+  python scripts/build_local_gui.py <output-dir>   # prepare the pruned tree
+  python scripts/build_local_gui.py --check        # perimeter check only
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from validate_local_surfaces import validate  # noqa: E402
+
+CONSOLE = Path("core/console")
+APP_DIR = CONSOLE / "src" / "app"
+MANIFEST = Path("apps/desktop-ui/surfaces.yaml")
+# Shell routes: the entry point and auth pages are not product surfaces, and
+# the local product needs them to boot.
+SHELL_ROUTES = {"/", "/login/", "/login/sso-callback/", "/welcome/"}
+
+
+def route_of(page: Path, app_dir: Path) -> str:
+    """URL path of a page file, ignoring Next route groups."""
+    rel = page.relative_to(app_dir).parent
+    parts = [p for p in rel.parts if not (p.startswith("(") and p.endswith(")"))]
+    return "/" + "".join(f"{p}/" for p in parts)
+
+
+def owned_routes(root: Path) -> set[str]:
+    manifest = yaml.safe_load((root / MANIFEST).read_text(encoding="utf-8"))
+    return set(manifest.get("owned_routes") or []) | SHELL_ROUTES
+
+
+def prune(tree: Path, keep: set[str]) -> list[str]:
+    """Delete every page outside the perimeter. Returns the removed routes.
+
+    A route directory can contain nested routes, and a kept route may live
+    under a removed one. Deepest-first, and never delete a directory that
+    still holds a page we keep — in that case only the route's own files go.
+    """
+    app_dir = tree / "src" / "app"
+    pages = sorted(app_dir.rglob("page.tsx"), key=lambda p: len(p.parts), reverse=True)
+    removed = []
+
+    for page in pages:
+        if not page.exists():  # its parent route was already removed
+            continue
+        route = route_of(page, app_dir)
+        if route in keep:
+            continue
+
+        directory = page.parent
+        holds_kept = any(
+            route_of(nested, app_dir) in keep
+            for nested in directory.rglob("page.tsx")
+            if nested != page
+        )
+        if holds_kept:
+            # Drop only this route's own files; the nested kept route stays.
+            for item in directory.iterdir():
+                if item.is_file():
+                    item.unlink()
+        else:
+            shutil.rmtree(directory)
+        removed.append(route)
+
+    return removed
+
+
+def main() -> int:
+    root = Path.cwd()
+
+    # A pruned tree built from a stale perimeter would ship the wrong product.
+    errors = validate(root)
+    if errors:
+        print("refusing to build: the declared perimeter does not match the source", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    if "--check" in sys.argv[1:]:
+        print("perimeter consistent with the source")
+        return 0
+
+    if len(sys.argv) < 2:
+        print("usage: build_local_gui.py <output-dir> | --check", file=sys.stderr)
+        return 2
+
+    out = Path(sys.argv[1]).resolve()
+    if out.exists():
+        shutil.rmtree(out)
+    shutil.copytree(
+        root / CONSOLE,
+        out,
+        ignore=shutil.ignore_patterns("node_modules", "out", ".next", "playwright"),
+    )
+
+    keep = owned_routes(root)
+    removed = prune(out, keep)
+
+    remaining = {
+        route_of(page, out / "src" / "app") for page in (out / "src" / "app").rglob("page.tsx")
+    }
+    foreign = sorted(remaining - keep)
+    if foreign:
+        print(f"pruning failed, still present: {foreign}", file=sys.stderr)
+        return 1
+
+    print(f"pruned build tree at {out}")
+    print(f"  kept {len(remaining)} routes, removed {len(removed)}")
+    print(f"  removed: {', '.join(removed)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_build_local_gui.py
+++ b/scripts/test_build_local_gui.py
@@ -1,0 +1,109 @@
+"""The pruning must be proven to remove the right things and keep the rest.
+
+The expensive proof — that the pruned tree actually compiles — was run against
+the real source (Next build green, exporting exactly the perimeter). These
+tests cover the pruning logic itself so a regression is caught without a build.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from build_local_gui import SHELL_ROUTES, owned_routes, prune, route_of  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def make_page(app_dir: Path, route_parts: list[str]) -> Path:
+    directory = app_dir.joinpath(*route_parts)
+    directory.mkdir(parents=True, exist_ok=True)
+    page = directory / "page.tsx"
+    page.write_text("export default function Page() { return null }\n", encoding="utf-8")
+    return page
+
+
+class TestRouteMapping(unittest.TestCase):
+    def test_route_groups_are_not_part_of_the_url(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = Path(tmp)
+            page = make_page(app, ["(app)", "tasks"])
+            self.assertEqual(route_of(page, app), "/tasks/")
+
+    def test_nested_route(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app = Path(tmp)
+            page = make_page(app, ["(app)", "settings", "users"])
+            self.assertEqual(route_of(page, app), "/settings/users/")
+
+
+class TestPruning(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="prune-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.app = self.tmp / "src" / "app"
+        self.app.mkdir(parents=True)
+
+    def test_keeps_owned_and_removes_foreign(self):
+        make_page(self.app, ["(app)", "tasks"])
+        make_page(self.app, ["(app)", "terminal"])
+        make_page(self.app, ["(app)", "settings", "users"])
+
+        removed = prune(self.tmp, {"/tasks/"})
+
+        self.assertEqual(sorted(removed), ["/settings/users/", "/terminal/"])
+        self.assertTrue((self.app / "(app)" / "tasks" / "page.tsx").exists())
+        self.assertFalse((self.app / "(app)" / "terminal").exists())
+
+    def test_a_kept_route_nested_under_a_removed_one_survives(self):
+        # The failure this guards against: removing /brain/ would take
+        # /brain/diario/ with it if the parent directory were deleted whole.
+        make_page(self.app, ["(app)", "brain"])
+        make_page(self.app, ["(app)", "brain", "diario"])
+
+        removed = prune(self.tmp, {"/brain/diario/"})
+
+        self.assertEqual(removed, ["/brain/"])
+        self.assertTrue((self.app / "(app)" / "brain" / "diario" / "page.tsx").exists())
+        self.assertFalse((self.app / "(app)" / "brain" / "page.tsx").exists())
+
+    def test_pruning_is_idempotent(self):
+        make_page(self.app, ["(app)", "tasks"])
+        make_page(self.app, ["(app)", "terminal"])
+
+        first = prune(self.tmp, {"/tasks/"})
+        second = prune(self.tmp, {"/tasks/"})
+
+        self.assertEqual(first, ["/terminal/"])
+        self.assertEqual(second, [])
+
+    def test_nothing_survives_outside_the_perimeter(self):
+        for parts in (["(app)", "tasks"], ["(app)", "terminal"], ["(app)", "monitoring"]):
+            make_page(self.app, parts)
+
+        prune(self.tmp, {"/tasks/"})
+
+        remaining = {route_of(p, self.app) for p in self.app.rglob("page.tsx")}
+        self.assertEqual(remaining, {"/tasks/"})
+
+
+class TestPerimeterSource(unittest.TestCase):
+    def test_shell_routes_are_kept_alongside_the_declared_ones(self):
+        keep = owned_routes(REPO_ROOT)
+        # Product surfaces come from the manifest; the shell must survive too
+        # or the local product cannot boot.
+        self.assertIn("/tasks/", keep)
+        self.assertTrue(SHELL_ROUTES.issubset(keep))
+
+    def test_forbidden_routes_are_not_in_the_kept_set(self):
+        keep = owned_routes(REPO_ROOT)
+        for route in ("/terminal/", "/settings/users/", "/monitoring/"):
+            self.assertNotIn(route, keep)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Third **U7** slice — the one that changes what actually ships. Implements the plan's *"escludere route Cloud e terminale"* at the point where it is decidable: the build.

## The problem, measured
The local wheel currently carries the **whole application**. 24 routes outside the local perimeter — `/terminal/`, hosted administration, SaaS — travel inside the release and **answer a direct URL**. Navigation hides them; the artifact does not.

## What changes
- **`scripts/build_local_gui.py`** — prunes a *copy* of the console source down to the perimeter declared in `apps/desktop-ui/surfaces.yaml`. The source tree is never modified. The perimeter is **read from the manifest**, not hardcoded, and the script **refuses to run when manifest and source have drifted** (reusing the slice-2 gate rather than duplicating it), so a stale declaration cannot produce an artifact.
- **`release.yml`** — builds the export from the pruned tree, then **fails the release if any forbidden route reached `console_dist`**. Checking the export rather than the intent is the lesson of 2026-07-23: one artifact serving several products passed every green check it had.

## Proof — run for real, not assumed
The pruned tree was installed and compiled with the actual Next build. The export contains exactly:

```
/  /diario  /login  /login/sso-callback  /projects  /tasks  /todos  /universe  /welcome  (+404)
```

| Forbidden class | Files in artifact |
|---|---|
| `/terminal/` `/settings/` `/monitoring/` `/brain/` `/graph/` `/inbox/` `/triage/` `/finder/` | **0** |

A pruned tree that did not compile would have been worse than no pruning, so the build was the gate for this slice — not the unit tests.

## Tests
23 green across the script suites. The pruning tests cover the case that would silently break the product: a **kept route nested under a removed one must survive** (found while writing it — the first implementation deleted parent directories whole), and pruning must be idempotent.

## Still open
The shared source still contains the foreign routes; only the *artifact* is now clean. Relocating the remaining source into `apps/desktop-ui/` is the next slice, and the perimeter gate keeps reporting the 24 routes until then. Desktop framework choice stays out (KTD4).

Task: aaab9758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvo6XZohWoMG9nKfZVFp3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvo6XZohWoMG9nKfZVFp3Q)_