### PR TITLE
feat(desktop): define the desktop host contract without choosing the shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         run: python scripts/validate_surfaces.py
       - name: Local GUI perimeter gate (declaration vs source)
         run: python scripts/validate_local_surfaces.py
+      - name: Desktop host contract gate (contract vs launcher)
+        run: python scripts/validate_desktop_host.py
       - name: Validator unit tests (green on good, red on tampered)
         run: python -m unittest discover -s scripts -p "test_*.py" -v
 

--- a/apps/desktop-ui/README.md
+++ b/apps/desktop-ui/README.md
@@ -1,22 +1,51 @@
-# MarvisX Console
-Mission Control Portal for MarvisX Team
+# Local GUI — owned by `marvis`
+
+The graphical interface of the local Marvis product. This directory is its
+source of truth: the wheel ships an export built from here, the local API
+serves it, and `marvis console` opens it.
+
+## Perimeter
+
+`surfaces.yaml` declares the routes this product owns. It is not documentation:
+`scripts/validate_local_surfaces.py` reads the navigation table out of
+`src/components/AppShell.tsx` and fails CI when the declaration and the code
+disagree, or when a route outside the perimeter appears here.
+
+Surfaces belonging to other products — the personal terminal Console, hosted
+multi-user administration, SaaS-only pages — are not part of this source and
+must not return. Before the U7 move they travelled inside the local release and
+answered a direct URL even though navigation hid them.
+
+## Build
+
+```bash
+npm ci
+NEXT_PUBLIC_LOCAL_MODE=1 NEXT_PUBLIC_API_URL="" npm run build
+```
+
+The static export lands in `out/`. The release workflow copies it into
+`core/api/console_dist/`, which is what the wheel carries.
 
 ## API types codegen
 
-Zod schemas and TS types for `/api/v1/graph/*` endpoints are generated from the backend Pydantic models:
+Zod schemas and TS types for graph endpoints are generated from the backend
+Pydantic models:
 
 ```bash
 npm run gen:types
 ```
 
-Regenerate whenever `api/models/graph_ux.py` or graph endpoint response shapes change.
-Commit `console/src/generated/api.ts` — it is the source of truth for frontend types.
+Regenerate whenever the graph endpoint response shapes change, and commit the
+generated file — it is the source of truth for frontend types. Always import
+from `@/lib/graphTypes`, never from `@/generated/api` directly.
 
-**How it works:** the script imports Pydantic models directly via Python (bypassing the broken
-`/openapi.json` live endpoint) and runs `openapi-zod-client` with the schemas-only template.
-Output is post-processed to add `Schema` suffix + `z.infer<>` type exports.
+## Receiving a desktop shell
 
-**Not impacted:** MCP tools (`mcp-pir/index.mjs`) — keep manual Zod schemas there.
+`contracts/desktop-host.yaml` (repository root) defines what a desktop shell may
+ask of the local runtime: the loopback endpoint, the capabilities it may drive,
+what it must never do, and where permissions live. **No shell technology has
+been chosen** — `docs/decisions/desktop-shell-selection.md` records the open
+decision and the criteria it must answer.
 
-**Import surface:** always import from `@/lib/graphTypes` (re-exports from generated + keeps
-custom types like `GraphKgNode`, `NodeId`, `OrphanNode`). Never import from `@/generated/api` directly.
+The browser launcher stays the compatibility path: a shell drives the documented
+capabilities, it does not reimplement them.

--- a/contracts/desktop-host.yaml
+++ b/contracts/desktop-host.yaml
@@ -1,0 +1,72 @@
+# Contract between a desktop shell and the local Marvis runtime.
+# U8 of the surface-separation plan (marvisx:docs/goals/2026-07-24-separate-surfaces.md).
+#
+# Purpose: let a future desktop plan choose a shell technology WITHOUT
+# reopening ownership, API surface or data lifecycle (KTD4). No technology is
+# named or implied here — see docs/decisions/desktop-shell-selection.md.
+#
+# Anchored to the real launcher: scripts/validate_desktop_host.py checks the
+# endpoint and every capability against core/cli/marvis_console.py, so this
+# cannot drift into prose that describes a product that no longer exists.
+schema_version: 1
+surface_id: desktop-ui
+owner_project: marvis
+
+# How a shell reaches the product. Loopback only: the local runtime is
+# single-user and never binds a public interface.
+endpoint:
+  host: 127.0.0.1
+  port: 8100
+  ui_path: /ui/
+  scheme: http
+
+# What a shell is allowed to do, and the CLI command that already does it.
+# The launcher stays the compatibility path: a shell drives these, it does not
+# reimplement them. Every entry must resolve to a registered command.
+capabilities:
+  open_gui:
+    command: console
+    description: Verify the packaged GUI, ensure the runtime answers, open the UI.
+  stop_runtime:
+    command: console
+    option: --stop
+    description: Stop the runtime this product started (pidfile under the vault dir).
+  autostart_enable:
+    command: autostart enable
+    description: Opt in to starting the runtime at login, via the OS mechanism.
+  autostart_disable:
+    command: autostart disable
+    description: Opt out of autostart.
+  autostart_status:
+    command: autostart status
+    description: Report whether autostart is registered.
+
+# What a shell must never do. These are ownership rules, not preferences:
+# breaking them moves product logic into the shell, which is exactly what a
+# later technology change would then have to renegotiate.
+forbidden:
+  direct_database_access: The runtime owns the database; a shell reads it through the API only.
+  bypass_local_api: Every product action goes through the local API, so permissions stay in one place.
+  embed_cloud_identity: WorkOS is Cloud-only (KTD6); the local product does not carry Cloud sessions.
+  ship_foreign_surfaces: The shell serves the local perimeter only (apps/desktop-ui/surfaces.yaml).
+  bind_public_interface: Loopback only; a desktop shell never exposes the runtime to the network.
+
+# Where authority lives. A shell asks; the runtime decides.
+permissions:
+  owner: local-runtime
+  rationale: >-
+    Permission checks live behind the API so CLI, MCP and any shell get the
+    same answer. A shell that decides for itself would create a second policy
+    that drifts from the first.
+
+# What a desktop package must satisfy, whatever technology is chosen later.
+packaging:
+  - Ships the local GUI export produced from apps/desktop-ui, nothing else.
+  - Starts the runtime through the documented capabilities, not by spawning
+    private commands.
+  - Degrades to the existing browser launcher when the shell is unavailable.
+  - Carries no credential, token or Cloud configuration at build time.
+
+# The choice of shell technology is deliberately NOT made here.
+shell_selection: open
+shell_selection_record: docs/decisions/desktop-shell-selection.md

--- a/docs/decisions/desktop-shell-selection.md
+++ b/docs/decisions/desktop-shell-selection.md
@@ -1,0 +1,52 @@
+---
+title: Desktop shell selection
+status: open
+date: 2026-07-29
+supersedes: none
+related:
+  - contracts/desktop-host.yaml
+  - apps/desktop-ui/surfaces.yaml
+  - marvisx:docs/plans/2026-07-24-separate-marvis-product-surfaces-plan.md
+---
+
+# Desktop shell selection
+
+## Status
+
+**Open.** No technology has been chosen. The surface-separation plan assigns
+the desktop GUI to `marvis` and deliberately does not select its shell (KTD4);
+an earlier premature commitment was removed from that plan for this reason.
+
+## What is already settled
+
+These do not need to be reopened when the shell is chosen:
+
+- The local product owns its GUI source (`apps/desktop-ui`) and its perimeter
+  is enforced in CI.
+- A shell reaches the product over loopback and drives the documented
+  capabilities; it does not reimplement them (`contracts/desktop-host.yaml`).
+- Permissions are owned by the local runtime, so CLI, MCP and any shell get
+  the same answer.
+- The browser launcher remains the compatibility path.
+
+## What the deciding ADR must answer
+
+1. **Runtime footprint** — installed size, memory at idle, cold start, measured
+   on the three supported platforms rather than quoted from documentation.
+2. **Threat model** — what the shell can reach that a browser cannot, how the
+   loopback endpoint is protected from other local processes, and what an
+   installed shell exposes if the machine is shared.
+3. **Update path** — how a shell updates itself, what happens when shell and
+   runtime versions disagree, and how a user recovers from a failed update.
+4. **Signing and notarization** — per platform, including who holds the
+   credentials and where they live. Credentials never enter this repository.
+5. **Offline behaviour** — what the shell does when the runtime is not
+   running, and whether it may start it.
+6. **Exit cost** — what has to change to replace the shell later. A candidate
+   that can only be replaced by rewriting product code fails this criterion.
+
+## Non-goals for that ADR
+
+Connecting the desktop shell to Cloud organizations, and any change to the
+ownership map, the local API surface or the data lifecycle. If a candidate
+requires one of those, that is a finding about the candidate.

--- a/scripts/test_validate_desktop_host.py
+++ b/scripts/test_validate_desktop_host.py
@@ -1,0 +1,113 @@
+"""The desktop host contract must be proven RED when it drifts from the
+launcher or when it quietly decides what it is not allowed to decide."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from validate_desktop_host import (  # noqa: E402
+    launcher_constants,
+    registered_commands,
+    validate,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = "contracts/desktop-host.yaml"
+LAUNCHER = "core/cli/marvis_console.py"
+
+
+class ContractCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dir = Path(tempfile.mkdtemp(prefix="desktop-host-"))
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        for rel in ("contracts", "docs/decisions", "apps/desktop-ui"):
+            (self.dir / rel).mkdir(parents=True, exist_ok=True)
+        shutil.copy(REPO_ROOT / CONTRACT, self.dir / CONTRACT)
+        (self.dir / "core/cli").mkdir(parents=True)
+        shutil.copy(REPO_ROOT / LAUNCHER, self.dir / LAUNCHER)
+        shutil.copy(
+            REPO_ROOT / "docs/decisions/desktop-shell-selection.md",
+            self.dir / "docs/decisions/desktop-shell-selection.md",
+        )
+        shutil.copy(
+            REPO_ROOT / "apps/desktop-ui/surfaces.yaml",
+            self.dir / "apps/desktop-ui/surfaces.yaml",
+        )
+
+    def rewrite(self, rel: str, old: str, new: str) -> None:
+        path = self.dir / rel
+        path.write_text(path.read_text(encoding="utf-8").replace(old, new, 1), encoding="utf-8")
+
+
+class TestParsing(unittest.TestCase):
+    def test_endpoint_constants_come_from_the_launcher(self) -> None:
+        constants = launcher_constants((REPO_ROOT / LAUNCHER).read_text(encoding="utf-8"))
+        self.assertEqual(constants["_HOST"], "127.0.0.1")
+        self.assertEqual(constants["_UI_PATH"], "/ui/")
+
+    def test_registered_commands_include_subapp_verbs(self) -> None:
+        commands = registered_commands((REPO_ROOT / LAUNCHER).read_text(encoding="utf-8"))
+        self.assertIn("console", commands)
+        self.assertIn("autostart enable", commands)
+
+
+class TestContractGate(ContractCase):
+    def test_real_contract_matches_the_real_launcher(self) -> None:
+        self.assertEqual(validate(REPO_ROOT), [])
+
+    def test_red_endpoint_drifts_from_the_launcher(self) -> None:
+        # The launcher still opens 8100; a contract claiming otherwise would
+        # send a shell to a port nothing serves.
+        self.rewrite(CONTRACT, "port: 8100", "port: 9999")
+        errors = validate(self.dir)
+        self.assertTrue(any("endpoint port" in e for e in errors), errors)
+
+    def test_red_capability_without_a_command(self) -> None:
+        self.rewrite(
+            CONTRACT,
+            "  open_gui:\n    command: console",
+            "  open_gui:\n    command: teleport",
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("unknown command" in e for e in errors), errors)
+
+    def test_red_runtime_leaves_loopback(self) -> None:
+        self.rewrite(CONTRACT, "host: 127.0.0.1", "host: 0.0.0.0")
+        errors = validate(self.dir)
+        self.assertTrue(any("loopback" in e for e in errors), errors)
+
+    def test_red_permissions_moved_to_the_shell(self) -> None:
+        # A shell that decides for itself creates a second policy that drifts
+        # from the runtime's.
+        self.rewrite(CONTRACT, "owner: local-runtime", "owner: desktop-shell")
+        errors = validate(self.dir)
+        self.assertTrue(any("permissions owner" in e for e in errors), errors)
+
+    def test_red_shell_technology_decided_here(self) -> None:
+        # KTD4: this contract prepares for a shell, it does not pick one.
+        self.rewrite(CONTRACT, "shell_selection: open", "shell_selection: decided")
+        errors = validate(self.dir)
+        self.assertTrue(any("must stay open" in e for e in errors), errors)
+
+    def test_red_forbidden_rule_without_a_reason(self) -> None:
+        self.rewrite(
+            CONTRACT,
+            "  direct_database_access: The runtime owns the database; a shell reads it through the API only.",
+            "  direct_database_access:",
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("no rationale" in e for e in errors), errors)
+
+    def test_red_missing_decision_record(self) -> None:
+        (self.dir / "docs/decisions/desktop-shell-selection.md").unlink()
+        errors = validate(self.dir)
+        self.assertTrue(any("shell_selection_record" in e for e in errors), errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_local_surfaces.py
+++ b/scripts/test_validate_local_surfaces.py
@@ -25,8 +25,11 @@ class PerimeterCase(unittest.TestCase):
     def setUp(self) -> None:
         self.dir = Path(tempfile.mkdtemp(prefix="perimeter-"))
         self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        # Skip build output: a local `npm ci` leaves ~1 GB under apps/, and
+        # copying it turns a sub-second suite into minutes.
+        ignore = shutil.ignore_patterns("node_modules", ".next", "out")
         for rel in ("apps",):
-            shutil.copytree(REPO_ROOT / rel, self.dir / rel)
+            shutil.copytree(REPO_ROOT / rel, self.dir / rel, ignore=ignore)
 
     def rewrite(self, rel: str, old: str, new: str) -> None:
         path = self.dir / rel

--- a/scripts/validate_desktop_host.py
+++ b/scripts/validate_desktop_host.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Fail-closed gate for the desktop host contract (U8).
+
+A contract that only lives in prose stops matching the product within weeks.
+This checks contracts/desktop-host.yaml against the real launcher: the loopback
+endpoint must be the one the launcher opens, and every declared capability must
+resolve to a command the CLI actually registers.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+CONTRACT = Path("contracts/desktop-host.yaml")
+LAUNCHER = Path("core/cli/marvis_console.py")
+PERIMETER = Path("apps/desktop-ui/surfaces.yaml")
+
+
+def launcher_constants(source: str) -> dict[str, str]:
+    """Endpoint constants as the launcher defines them."""
+    found = {}
+    for name in ("_HOST", "_PORT", "_UI_PATH"):
+        match = re.search(rf'^{name} = "?([^"\n]+)"?$', source, re.MULTILINE)
+        if match:
+            found[name] = match.group(1)
+    return found
+
+
+def registered_commands(source: str) -> set[str]:
+    """Commands the launcher attaches to the CLI, including sub-app verbs."""
+    # Registration carries extra keyword arguments (help panels), so match the
+    # command name without requiring the call to close straight after it.
+    commands = set(re.findall(r'(?<!_)app\.command\(\s*"([^"]+)"', source))
+    for sub in re.findall(r'add_typer\(\s*\w+,\s*\n?\s*name="([^"]+)"', source):
+        commands.add(sub)
+    # Verbs registered on a sub-app (autostart enable/disable/status).
+    for group, verb in re.findall(r'(\w+)_app\.command\(\s*"([^"]+)"', source):
+        commands.add(f"{group} {verb}")
+    return commands
+
+
+def validate(root: Path) -> list[str]:
+    errors: list[str] = []
+    contract = yaml.safe_load((root / CONTRACT).read_text(encoding="utf-8"))
+    launcher = (root / LAUNCHER).read_text(encoding="utf-8")
+
+    if contract.get("owner_project") != "marvis":
+        errors.append("desktop-host: owner_project must be marvis")
+
+    # 1. The endpoint must be the one the launcher really opens.
+    endpoint = contract.get("endpoint") or {}
+    constants = launcher_constants(launcher)
+    expected = {
+        "host": constants.get("_HOST"),
+        "port": constants.get("_PORT"),
+        "ui_path": constants.get("_UI_PATH"),
+    }
+    for key, real in expected.items():
+        if real is None:
+            errors.append(f"desktop-host: cannot read {key} from the launcher")
+            continue
+        declared = str(endpoint.get(key, ""))
+        if declared != real:
+            errors.append(f"desktop-host: endpoint {key} is {declared!r}, launcher uses {real!r}")
+    if endpoint.get("host") not in {"127.0.0.1", "localhost"}:
+        errors.append("desktop-host: the runtime must stay on loopback")
+
+    # 2. Every capability must resolve to a command that exists.
+    commands = registered_commands(launcher)
+    capabilities = contract.get("capabilities") or {}
+    if not capabilities:
+        errors.append("desktop-host: no capabilities declared — refusing to pass")
+    for name, spec in capabilities.items():
+        command = (spec or {}).get("command")
+        if not command:
+            errors.append(f"desktop-host: capability {name} declares no command")
+            continue
+        root_command = command.split()[0]
+        if command not in commands and root_command not in commands:
+            errors.append(f"desktop-host: capability {name} maps to unknown command {command!r}")
+
+    # 3. Forbidden rules must carry a reason; an empty rule is decoration.
+    forbidden = contract.get("forbidden") or {}
+    if not forbidden:
+        errors.append("desktop-host: no forbidden rules declared — refusing to pass")
+    for name, reason in forbidden.items():
+        if not str(reason or "").strip():
+            errors.append(f"desktop-host: forbidden rule {name} has no rationale")
+    overlap = set(forbidden) & set(capabilities)
+    if overlap:
+        errors.append(f"desktop-host: declared both allowed and forbidden: {sorted(overlap)}")
+
+    # 4. Permissions belong to the runtime, never to the shell.
+    if (contract.get("permissions") or {}).get("owner") != "local-runtime":
+        errors.append("desktop-host: permissions owner must be local-runtime")
+
+    # 5. The shell selection stays open here (KTD4): this contract must not
+    #    name or imply a technology.
+    if contract.get("shell_selection") != "open":
+        errors.append("desktop-host: shell_selection must stay open — the choice is a separate ADR")
+    record = contract.get("shell_selection_record")
+    if not record or not (root / record).is_file():
+        errors.append("desktop-host: shell_selection_record must point at an existing document")
+
+    # 6. The perimeter it serves must be the one the local product owns.
+    if not (root / PERIMETER).is_file():
+        errors.append(f"desktop-host: {PERIMETER} is missing — no perimeter to serve")
+
+    return errors
+
+
+def main() -> int:
+    root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    errors = validate(root)
+    if errors:
+        print("desktop host contract INVALID:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(
+        "desktop host contract valid: endpoint and capabilities match the launcher, "
+        "permissions stay with the runtime, shell choice still open"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**U8**, the last unit of the separation plan that can be completed without touching a live surface. U7 gave the local product its own GUI source; this prepares it to receive a desktop shell **without picking one** (KTD4).

## What this defines
- **`contracts/desktop-host.yaml`** — how a shell reaches the runtime (**loopback only**), which capabilities it may drive, what it must **never** do, and where permissions live:

| Forbidden | Why |
|---|---|
| Direct database access | The runtime owns the data; a shell reads through the API |
| Bypassing the local API | Permissions stay in one place |
| Embedding Cloud identity | WorkOS is Cloud-only (KTD6) |
| Shipping foreign surfaces | The shell serves the local perimeter only |
| Binding a public interface | A desktop shell never exposes the runtime to the network |

Every rule carries its rationale — a rule without a reason gets deleted by the next person who finds it inconvenient.

- **`scripts/validate_desktop_host.py`** — the contract is **anchored to the real launcher**: host, port and UI path must match `core/cli/marvis_console.py`, and every declared capability must resolve to a command the CLI actually registers. A contract describing a product that no longer exists fails CI instead of misleading whoever writes the shell.

- **`docs/decisions/desktop-shell-selection.md`** — the decision recorded as **open**, with what a future ADR must answer: footprint measured on the supported platforms rather than quoted, threat model for a shell reaching loopback, update path when shell and runtime disagree, signing per platform, offline behaviour, and **exit cost** (a candidate replaceable only by rewriting product code fails). No technology named or implied — and the gate **fails if this contract ever claims the choice is made.**

## Verification
25 tests green, with a red path for each failure mode: endpoint drift, unknown capability, runtime off loopback, permissions moved to the shell, technology decided here, forbidden rule without rationale, missing decision record.

## Two fixes along the way
- `apps/desktop-ui/README.md` described a team portal; it now describes the local product's owned GUI.
- The U7 build left ~1 GB of dependencies under `apps/`, and the perimeter tests copied the whole tree — the suite had gone from **0.4s to 189s**. Build output is now excluded.

Task: 1ed4bd88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uvo6XZohWoMG9nKfZVFp3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvo6XZohWoMG9nKfZVFp3Q)_