### PR TITLE
fix(surfaces): close the six registry-gate holes Codex found on #41

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify the local GUI perimeter
-        # The source IS the perimeter since the U7 move, so this only has to
-        # confirm nothing foreign crept in — no pruning step to trust.
+      - name: Verify the surface registry and the local GUI perimeter
+        # A `v*` tag starts this workflow directly, and the CI workflow that
+        # carries the registry gate only runs on pull requests and pushes to
+        # main. Without this step a tagged commit reached the human-gated
+        # publish job with an unvalidated registry — the one path that skipped
+        # the gate was the one that ships.
+        #
+        # The perimeter check that follows only has to confirm nothing foreign
+        # crept in: the source IS the perimeter since the U7 move.
         run: |
           set -euo pipefail
           python -m pip install --quiet pyyaml
+          python scripts/validate_surfaces.py
           python scripts/validate_local_surfaces.py
+          python scripts/validate_desktop_host.py
 
       - name: Build the local GUI static export in Docker
         run: |

--- a/contracts/surfaces/desktop-ui.yaml
+++ b/contracts/surfaces/desktop-ui.yaml
@@ -1,24 +1,49 @@
-# Surface manifest — future desktop/local GUI owned by marvis (U7/U8). STUB,
-# fail-closed: declared so the registry can tell this surface apart from the
-# CLI wheel and from foreign product GUIs, but NOT deployable. Flipping
-# deployable requires proof for every prerequisite below. No desktop framework
-# is named here — that choice belongs to a separate ADR (plan KTD4).
+# Surface manifest — the local GUI owned by marvis (U7/U8).
+#
+# This manifest used to declare deployable: false and describe a desktop shell
+# that does not exist, while the local GUI has been shipping for months:
+# release.yml builds apps/desktop-ui, copies the export into
+# core/api/console_dist/, pyproject.toml ships that directory in the wheel, and
+# core/api/ui_static.py serves it at /ui/. The registry reported green over a
+# real, unregistered surface — the artifact-mismatch class it exists to prevent.
+#
+# The shell technology choice is a separate question and is still open
+# (docs/decisions/desktop-shell-selection.md). Packaging the GUI into a desktop
+# app is gated below, on its own flag; the browser launcher is the shipping path
+# today.
 surface_id: desktop-ui
 owner_project: marvis
 owner_repo: emiliomartucci/marvis
-contract_version: 1
+contract_version: 2
 description: >-
-  Desktop/local GUI for the marvis product. Owned by marvis; never built from
-  or served by marvisx UI bundles (KTD10), never a Cloud or terminal surface.
+  Local GUI for the marvis product: built from apps/desktop-ui, shipped inside
+  the wheel and served by the local runtime at /ui/. Owned by marvis; never
+  built from or served by marvisx UI bundles (KTD10), never a Cloud or terminal
+  surface.
 
-deployable: false
+# The GUI ships today. scripts/validate_surfaces.py checks this claim against
+# the release workflow and the wheel packaging, so it cannot become a wish.
+deployable: true
 
-# U7/U8 gate — each key must map to non-empty evidence before deployable may
-# become true. The validator enforces this shape.
+ships_as:
+  built_from: apps/desktop-ui
+  bundled_at: core/api/console_dist
+  served_at: /ui/
+
+# Each key must name a file that exists. The set is fixed in the validator, not
+# read from here: a gate that lets the audited file choose what it is audited
+# against certifies whatever it was handed.
 prerequisites:
-  local_gui_characterization: null
-  desktop_host_contract: null
-  shell_adr_decision: null
+  local_gui_characterization: core/cli/tests/test_marvis_console_characterization.py
+  desktop_host_contract: contracts/desktop-host.yaml
+  perimeter_gate: scripts/validate_local_surfaces.py
+
+# Packaging the GUI as an installed desktop application. Distinct from shipping
+# the GUI itself: it needs a shell technology, and that decision is open. The
+# validator refuses to flip this while the ADR is not accepted.
+desktop_shell:
+  deployable: false
+  decision_record: docs/decisions/desktop-shell-selection.md
 
 forbidden_sources:
   - marvisx:core/console

--- a/scripts/test_validate_surfaces.py
+++ b/scripts/test_validate_surfaces.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import sys
 import tempfile
@@ -153,8 +154,16 @@ class TestValidator(FixtureCase):
         errors = validate(self.dir)
         self.assertTrue(any("is not accepted" in e for e in errors), errors)
 
-    def test_desktop_shell_allowed_once_the_adr_is_accepted(self) -> None:
+    def test_desktop_shell_allowed_once_the_adr_is_accepted_and_something_packages_it(self) -> None:
         self.rewrite(DESKTOP, "desktop_shell:\n  deployable: false", "desktop_shell:\n  deployable: true")
+        self.rewrite(
+            DESKTOP,
+            "  decision_record: docs/decisions/desktop-shell-selection.md",
+            "  decision_record: docs/decisions/desktop-shell-selection.md\n"
+            "  packaged_as:\n"
+            "    built_by: apps/desktop-ui\n"
+            "    artifact: a desktop application bundle",
+        )
         self.rewrite("docs/decisions/desktop-shell-selection.md", "status: open", "status: accepted")
         self.assertEqual(validate(self.dir), [])
 
@@ -207,6 +216,39 @@ class TestValidator(FixtureCase):
         errors = validate(self.dir)
         self.assertTrue(any("does not ship console_dist" in e for e in errors), errors)
 
+    def test_red_broadened_shipping_paths(self) -> None:
+        # `built_from: apps` and `bundled_at: console_dist` both matched the
+        # workflow and the package data while naming neither the source nor the
+        # bundle.
+        self.rewrite(DESKTOP, "built_from: apps/desktop-ui", "built_from: apps")
+        self.rewrite(DESKTOP, "bundled_at: core/api/console_dist", "bundled_at: console_dist")
+        errors = validate(self.dir)
+        self.assertTrue(any("built_from must be apps/desktop-ui" in e for e in errors), errors)
+        self.assertTrue(any("bundled_at must be core/api/console_dist" in e for e in errors), errors)
+
+    def test_red_package_data_under_the_wrong_package(self) -> None:
+        self.rewrite("pyproject.toml", '"core.api" = ["console_dist/**/*"]', '"projects" = ["console_dist/**/*"]')
+        errors = validate(self.dir)
+        self.assertTrue(any("does not ship console_dist" in e for e in errors), errors)
+
+    def test_red_decision_record_pointing_at_another_adr(self) -> None:
+        # The manifest would otherwise pick whichever accepted ADR exists and
+        # authorise itself with it.
+        other = self.dir / "docs/decisions/something-else.md"
+        other.write_text("---\nstatus: accepted\n---\n\n# Other\n", encoding="utf-8")
+        self.rewrite(DESKTOP, "decision_record: docs/decisions/desktop-shell-selection.md", "decision_record: docs/decisions/something-else.md")
+        self.rewrite(DESKTOP, "desktop_shell:\n  deployable: false", "desktop_shell:\n  deployable: true")
+        errors = validate(self.dir)
+        self.assertTrue(any("decision_record must be" in e for e in errors), errors)
+
+    def test_red_shell_deployable_without_any_packaging(self) -> None:
+        # An accepted ADR decides WHICH shell, not that one exists. Nothing
+        # packages a desktop application today.
+        self.rewrite(DESKTOP, "desktop_shell:\n  deployable: false", "desktop_shell:\n  deployable: true")
+        self.rewrite("docs/decisions/desktop-shell-selection.md", "status: open", "status: accepted")
+        errors = validate(self.dir)
+        self.assertTrue(any("requires a packaged_as block" in e for e in errors), errors)
+
     def test_red_tampered_engine_pin(self) -> None:
         self.rewrite(
             "contracts/engine-pin.yaml",
@@ -229,6 +271,13 @@ class TestReleasePathRunsTheGate(unittest.TestCase):
     def commands(self, root: Path) -> list[str]:
         return release_run_commands(root)
 
+    @staticmethod
+    def invokes(commands: list[str], script: str) -> bool:
+        """The script must be what the line runs, not something it mentions."""
+        return any(
+            re.match(rf"^(python3?|py)\s+{re.escape(script)}(\s|$)", line) for line in commands
+        )
+
     def test_release_workflow_runs_every_registry_gate(self) -> None:
         commands = self.commands(REPO_ROOT)
         for gate in (
@@ -236,9 +285,26 @@ class TestReleasePathRunsTheGate(unittest.TestCase):
             "scripts/validate_local_surfaces.py",
             "scripts/validate_desktop_host.py",
         ):
-            self.assertTrue(
-                any(gate in line for line in commands), f"{gate} does not run on the tag path"
-            )
+            self.assertTrue(self.invokes(commands, gate), f"{gate} does not run on the tag path")
+
+    def test_a_mentioned_gate_is_not_an_invoked_gate(self) -> None:
+        workspace = Path(tempfile.mkdtemp(prefix="release-"))
+        self.addCleanup(shutil.rmtree, workspace, ignore_errors=True)
+        target = workspace / RELEASE
+        target.parent.mkdir(parents=True)
+        text = (REPO_ROOT / RELEASE).read_text(encoding="utf-8")
+        target.write_text(
+            text.replace(
+                "          python scripts/validate_surfaces.py",
+                "          echo python scripts/validate_surfaces.py",
+            ),
+            encoding="utf-8",
+        )
+        commands = self.commands(workspace)
+        self.assertFalse(
+            self.invokes(commands, "scripts/validate_surfaces.py"),
+            "a script merely echoed is not a gate",
+        )
 
     def test_release_workflow_gates_before_it_builds(self) -> None:
         commands = self.commands(REPO_ROOT)

--- a/scripts/test_validate_surfaces.py
+++ b/scripts/test_validate_surfaces.py
@@ -10,7 +10,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from validate_surfaces import validate  # noqa: E402
+from validate_surfaces import release_run_commands, validate  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DESKTOP = "contracts/surfaces/desktop-ui.yaml"
@@ -127,7 +127,13 @@ class TestValidator(FixtureCase):
     def test_red_prerequisite_pointing_at_nothing(self) -> None:
         self.rewrite(DESKTOP, "desktop_host_contract: contracts/desktop-host.yaml", "desktop_host_contract: contracts/imaginary.yaml")
         errors = validate(self.dir)
-        self.assertTrue(any("does not exist in the tree" in e for e in errors), errors)
+        self.assertTrue(any("must name contracts/desktop-host.yaml" in e for e in errors), errors)
+
+    def test_red_evidence_deleted_from_the_tree(self) -> None:
+        # The manifest still names the right artifact; the artifact is gone.
+        (self.dir / "contracts/desktop-host.yaml").unlink()
+        errors = validate(self.dir)
+        self.assertTrue(any("is not a file in the tree" in e for e in errors), errors)
 
     def test_red_shipping_claim_the_release_does_not_honour(self) -> None:
         # `deployable: true` is a claim about the release, so it is read against
@@ -152,6 +158,55 @@ class TestValidator(FixtureCase):
         self.rewrite("docs/decisions/desktop-shell-selection.md", "status: open", "status: accepted")
         self.assertEqual(validate(self.dir), [])
 
+    def test_red_prerequisite_pointing_at_an_unrelated_file(self) -> None:
+        # Checking only that the path exists let any file stand in for the proof
+        # it was supposed to name.
+        self.rewrite(DESKTOP, "desktop_host_contract: contracts/desktop-host.yaml", "desktop_host_contract: pyproject.toml")
+        errors = validate(self.dir)
+        self.assertTrue(any("must name contracts/desktop-host.yaml" in e for e in errors), errors)
+
+    def test_red_prerequisite_pointing_at_a_directory(self) -> None:
+        self.rewrite(DESKTOP, "perimeter_gate: scripts/validate_local_surfaces.py", "perimeter_gate: .")
+        errors = validate(self.dir)
+        self.assertTrue(any("must name scripts/validate_local_surfaces.py" in e for e in errors), errors)
+
+    def test_red_served_at_drifting_from_the_host_contract(self) -> None:
+        # The route is fixed by the desktop host contract; the shipping claim
+        # could name any path and stay green.
+        self.rewrite(DESKTOP, "served_at: /ui/", "served_at: /wrong/")
+        errors = validate(self.dir)
+        self.assertTrue(any("served_at" in e and "ui_path" in e for e in errors), errors)
+
+    def test_red_non_boolean_desktop_shell_flag(self) -> None:
+        # `"true"` is not `is True`, so the identity check read a malformed
+        # truthy value as undeployable and skipped the ADR gate.
+        self.rewrite(DESKTOP, "desktop_shell:\n  deployable: false", 'desktop_shell:\n  deployable: "true"')
+        errors = validate(self.dir)
+        self.assertTrue(any("must be a boolean" in e for e in errors), errors)
+
+    def test_red_adr_accepted_only_inside_the_body(self) -> None:
+        # A whole-document search matched an example in the prose and read an
+        # open ADR as decided.
+        self.rewrite(DESKTOP, "desktop_shell:\n  deployable: false", "desktop_shell:\n  deployable: true")
+        self.rewrite(
+            "docs/decisions/desktop-shell-selection.md",
+            "## Status",
+            "## Status\n\nA later ADR will read:\n\n```yaml\nstatus: accepted\n```\n",
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("is not accepted" in e for e in errors), errors)
+
+    def test_red_package_data_entry_commented_out(self) -> None:
+        # Commenting the entry is how a setuptools setting is usually disabled;
+        # the raw-text check still found the string and stayed green.
+        self.rewrite(
+            "pyproject.toml",
+            '"core.api" = ["console_dist/**/*"]',
+            '# "core.api" = ["console_dist/**/*"]',
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("does not ship console_dist" in e for e in errors), errors)
+
     def test_red_tampered_engine_pin(self) -> None:
         self.rewrite(
             "contracts/engine-pin.yaml",
@@ -166,24 +221,48 @@ class TestReleasePathRunsTheGate(unittest.TestCase):
     """A `v*` tag starts release.yml directly and skips the CI workflow.
 
     The registry gate has to run on the path that ships, not only on the path
-    that reviews.
+    that reviews. Read from the parsed workflow: a commented-out
+    `# python scripts/validate_surfaces.py` still contains the script name, so a
+    text search reported a gate that no longer executes.
     """
 
+    def commands(self, root: Path) -> list[str]:
+        return release_run_commands(root)
+
     def test_release_workflow_runs_every_registry_gate(self) -> None:
-        workflow = (REPO_ROOT / RELEASE).read_text(encoding="utf-8")
+        commands = self.commands(REPO_ROOT)
         for gate in (
             "scripts/validate_surfaces.py",
             "scripts/validate_local_surfaces.py",
             "scripts/validate_desktop_host.py",
         ):
-            self.assertIn(gate, workflow, f"{gate} does not run on the tag path")
+            self.assertTrue(
+                any(gate in line for line in commands), f"{gate} does not run on the tag path"
+            )
 
     def test_release_workflow_gates_before_it_builds(self) -> None:
-        workflow = (REPO_ROOT / RELEASE).read_text(encoding="utf-8")
-        self.assertLess(
-            workflow.index("scripts/validate_surfaces.py"),
-            workflow.index("Build the local GUI static export"),
-            "the registry gate must run before anything is built",
+        commands = self.commands(REPO_ROOT)
+        gate = next(i for i, l in enumerate(commands) if "scripts/validate_surfaces.py" in l)
+        build = next(i for i, l in enumerate(commands) if "npm run build" in l)
+        self.assertLess(gate, build, "the registry gate must run before anything is built")
+
+    def test_a_commented_out_gate_is_not_a_gate(self) -> None:
+        workspace = Path(tempfile.mkdtemp(prefix="release-"))
+        self.addCleanup(shutil.rmtree, workspace, ignore_errors=True)
+        target = workspace / RELEASE
+        target.parent.mkdir(parents=True)
+        text = (REPO_ROOT / RELEASE).read_text(encoding="utf-8")
+        target.write_text(
+            text.replace(
+                "          python scripts/validate_surfaces.py",
+                "          # python scripts/validate_surfaces.py",
+            ),
+            encoding="utf-8",
+        )
+        commands = self.commands(workspace)
+        self.assertFalse(
+            any("scripts/validate_surfaces.py" in line for line in commands),
+            "a commented-out command must not count as a gate",
         )
 
 

--- a/scripts/test_validate_surfaces.py
+++ b/scripts/test_validate_surfaces.py
@@ -13,6 +13,17 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from validate_surfaces import validate  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+DESKTOP = "contracts/surfaces/desktop-ui.yaml"
+CLI = "contracts/surfaces/marvis-cli.yaml"
+RELEASE = ".github/workflows/release.yml"
+# Files the manifests point at. The validator resolves the evidence, so the
+# fixture has to carry it or every case would go red for the wrong reason.
+EVIDENCE = (
+    "core/cli/tests/test_marvis_console_characterization.py",
+    "contracts/desktop-host.yaml",
+    "scripts/validate_local_surfaces.py",
+    "docs/decisions/desktop-shell-selection.md",
+)
 
 
 class FixtureCase(unittest.TestCase):
@@ -21,49 +32,125 @@ class FixtureCase(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
         shutil.copytree(REPO_ROOT / "contracts", self.dir / "contracts")
         shutil.copy(REPO_ROOT / "pyproject.toml", self.dir / "pyproject.toml")
+        (self.dir / "apps/desktop-ui").mkdir(parents=True)
+        for rel in (RELEASE, *EVIDENCE):
+            target = self.dir / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(REPO_ROOT / rel, target)
 
     def rewrite(self, rel: str, old: str, new: str) -> None:
         path = self.dir / rel
-        path.write_text(path.read_text(encoding="utf-8").replace(old, new), encoding="utf-8")
+        text = path.read_text(encoding="utf-8")
+        assert old in text, f"fixture anchor not found in {rel}: {old!r}"
+        path.write_text(text.replace(old, new), encoding="utf-8")
 
 
 class TestValidator(FixtureCase):
     def test_real_repo_state_is_green(self) -> None:
         self.assertEqual(validate(REPO_ROOT), [])
 
+    def test_fixture_is_green_before_tampering(self) -> None:
+        # Otherwise a red case below could pass for a reason it never tested.
+        self.assertEqual(validate(self.dir), [])
+
     def test_red_wrong_distribution_name(self) -> None:
-        self.rewrite(
-            "contracts/surfaces/marvis-cli.yaml",
-            "distribution_name: marvisx-cli",
-            "distribution_name: some-other-wheel",
-        )
+        self.rewrite(CLI, "distribution_name: marvisx-cli", "distribution_name: some-other-wheel")
         errors = validate(self.dir)
         self.assertTrue(any("distribution_name" in e for e in errors), errors)
 
+    def test_red_missing_distribution_name(self) -> None:
+        # Deleting the field used to make the wheel cross-check silent: the
+        # comparison was guarded by `declared and ...`, so absent read as fine.
+        self.rewrite(CLI, "distribution_name: marvisx-cli\n", "")
+        errors = validate(self.dir)
+        self.assertTrue(
+            any("distribution_name must be a non-empty string" in e for e in errors), errors
+        )
+
     def test_red_foreign_hostname_claim(self) -> None:
         self.rewrite(
-            "contracts/surfaces/marvis-cli.yaml",
+            CLI,
             "artifact_kind: python-wheel",
             "artifact_kind: python-wheel\nallowed_hostnames:\n  - console.justaskmarvis.com",
         )
         errors = validate(self.dir)
         self.assertTrue(any("owned by another product" in e for e in errors), errors)
 
-    def test_red_desktop_ui_flipped_without_proof(self) -> None:
-        self.rewrite(
-            "contracts/surfaces/desktop-ui.yaml", "deployable: false", "deployable: true"
-        )
-        errors = validate(self.dir)
-        self.assertTrue(any("prerequisites without proof" in e for e in errors), errors)
+    def test_red_foreign_hostname_in_a_different_spelling(self) -> None:
+        # DNS reads these as the same host; a raw membership test read them as
+        # strangers and let the claim through.
+        for spelling in ("Console.JustAskMarvis.com", "console.justaskmarvis.com.", "CONSOLE.justaskmarvis.COM"):
+            with self.subTest(spelling=spelling):
+                self.setUp()
+                self.rewrite(
+                    CLI,
+                    "artifact_kind: python-wheel",
+                    f"artifact_kind: python-wheel\nallowed_hostnames:\n  - {spelling}",
+                )
+                errors = validate(self.dir)
+                self.assertTrue(any("owned by another product" in e for e in errors), errors)
 
     def test_red_wrong_owner_project(self) -> None:
-        self.rewrite(
-            "contracts/surfaces/marvis-cli.yaml",
-            "owner_project: marvis",
-            "owner_project: marvisx",
-        )
+        self.rewrite(CLI, "owner_project: marvis", "owner_project: marvisx")
         errors = validate(self.dir)
         self.assertTrue(any("owner_project" in e for e in errors), errors)
+
+    def test_red_falsy_owner_values(self) -> None:
+        # `0` satisfied the old required-field check by explicit exemption and
+        # then skipped both comparisons behind a truthiness guard.
+        self.rewrite(CLI, "owner_project: marvis", "owner_project: 0")
+        self.rewrite(CLI, "owner_repo: emiliomartucci/marvis", "owner_repo: 0")
+        errors = validate(self.dir)
+        self.assertTrue(any("owner_project" in e for e in errors), errors)
+        self.assertTrue(any("owner_repo" in e for e in errors), errors)
+
+    def test_red_empty_owner_values(self) -> None:
+        self.rewrite(CLI, "owner_project: marvis", 'owner_project: ""')
+        errors = validate(self.dir)
+        self.assertTrue(any("owner_project must be a non-empty string" in e for e in errors), errors)
+
+    def test_red_prerequisites_replaced_with_an_arbitrary_key(self) -> None:
+        # The old gate computed `unproven` from the manifest's own mapping, so
+        # swapping in one evidenced key of any name passed.
+        self.rewrite(
+            DESKTOP,
+            "prerequisites:\n"
+            "  local_gui_characterization: core/cli/tests/test_marvis_console_characterization.py\n"
+            "  desktop_host_contract: contracts/desktop-host.yaml\n"
+            "  perimeter_gate: scripts/validate_local_surfaces.py\n",
+            "prerequisites:\n  looks_fine_to_me: pyproject.toml\n",
+        )
+        errors = validate(self.dir)
+        self.assertTrue(any("missing required keys" in e for e in errors), errors)
+        self.assertTrue(any("unknown keys" in e for e in errors), errors)
+
+    def test_red_prerequisite_pointing_at_nothing(self) -> None:
+        self.rewrite(DESKTOP, "desktop_host_contract: contracts/desktop-host.yaml", "desktop_host_contract: contracts/imaginary.yaml")
+        errors = validate(self.dir)
+        self.assertTrue(any("does not exist in the tree" in e for e in errors), errors)
+
+    def test_red_shipping_claim_the_release_does_not_honour(self) -> None:
+        # `deployable: true` is a claim about the release, so it is read against
+        # the release: a GUI nobody builds must not pass as shipped.
+        self.rewrite(RELEASE, "-w /repo/apps/desktop-ui", "-w /repo/apps/some-other-ui")
+        self.rewrite(RELEASE, "apps/desktop-ui/out", "apps/some-other-ui/out")
+        errors = validate(self.dir)
+        self.assertTrue(any("never builds apps/desktop-ui" in e for e in errors), errors)
+
+    def test_red_shipping_claim_the_wheel_does_not_honour(self) -> None:
+        self.rewrite("pyproject.toml", 'console_dist/**/*', "some_other_dir/**/*")
+        errors = validate(self.dir)
+        self.assertTrue(any("does not ship console_dist" in e for e in errors), errors)
+
+    def test_red_desktop_shell_claimed_while_the_adr_is_open(self) -> None:
+        self.rewrite(DESKTOP, "desktop_shell:\n  deployable: false", "desktop_shell:\n  deployable: true")
+        errors = validate(self.dir)
+        self.assertTrue(any("is not accepted" in e for e in errors), errors)
+
+    def test_desktop_shell_allowed_once_the_adr_is_accepted(self) -> None:
+        self.rewrite(DESKTOP, "desktop_shell:\n  deployable: false", "desktop_shell:\n  deployable: true")
+        self.rewrite("docs/decisions/desktop-shell-selection.md", "status: open", "status: accepted")
+        self.assertEqual(validate(self.dir), [])
 
     def test_red_tampered_engine_pin(self) -> None:
         self.rewrite(
@@ -73,6 +160,31 @@ class TestValidator(FixtureCase):
         )
         errors = validate(self.dir)
         self.assertTrue(any("engine_ref" in e for e in errors), errors)
+
+
+class TestReleasePathRunsTheGate(unittest.TestCase):
+    """A `v*` tag starts release.yml directly and skips the CI workflow.
+
+    The registry gate has to run on the path that ships, not only on the path
+    that reviews.
+    """
+
+    def test_release_workflow_runs_every_registry_gate(self) -> None:
+        workflow = (REPO_ROOT / RELEASE).read_text(encoding="utf-8")
+        for gate in (
+            "scripts/validate_surfaces.py",
+            "scripts/validate_local_surfaces.py",
+            "scripts/validate_desktop_host.py",
+        ):
+            self.assertIn(gate, workflow, f"{gate} does not run on the tag path")
+
+    def test_release_workflow_gates_before_it_builds(self) -> None:
+        workflow = (REPO_ROOT / RELEASE).read_text(encoding="utf-8")
+        self.assertLess(
+            workflow.index("scripts/validate_surfaces.py"),
+            workflow.index("Build the local GUI static export"),
+            "the registry gate must run before anything is built",
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/validate_surfaces.py
+++ b/scripts/validate_surfaces.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import re
 import sys
+import tomllib
 from pathlib import Path
 
 import yaml
@@ -36,18 +37,25 @@ FOREIGN_HOSTNAMES = {
     "app.justaskmarvis.com",
     "api.justaskmarvis.com",
 }
-# The proofs a deployable local GUI owes, fixed here rather than read from the
-# manifest: a gate that lets the audited file decide what it is audited against
-# only certifies whatever it was handed.
-REQUIRED_DESKTOP_PREREQUISITES = frozenset(
-    {"local_gui_characterization", "desktop_host_contract", "perimeter_gate"}
-)
+# The proofs a deployable local GUI owes, and the artifact each one means.
+# Fixed here rather than read from the manifest, keys AND values: a gate that
+# lets the audited file decide what it is audited against certifies whatever it
+# was handed, and checking only that the path exists lets any existing file —
+# `pyproject.toml`, or `.` — stand in for the real evidence.
+REQUIRED_DESKTOP_PREREQUISITES = {
+    "local_gui_characterization": "core/cli/tests/test_marvis_console_characterization.py",
+    "desktop_host_contract": "contracts/desktop-host.yaml",
+    "perimeter_gate": "scripts/validate_local_surfaces.py",
+}
+DESKTOP_HOST_CONTRACT = Path("contracts/desktop-host.yaml")
 # What a shipping local GUI must be true of, read from the files that do the
 # shipping. `deployable: true` is a claim about the release, so it is checked
 # against the release.
 RELEASE_WORKFLOW = Path(".github/workflows/release.yml")
 PYPROJECT = Path("pyproject.toml")
-ADR_ACCEPTED_RE = re.compile(r"^status:\s*accepted\s*$", re.IGNORECASE | re.MULTILINE)
+# Front matter only. A whole-document search matched `status: accepted` inside
+# a fenced example or a migration note and read an open ADR as decided.
+FRONT_MATTER_RE = re.compile(r"\A---\n(.*?)\n---\s*\n", re.DOTALL)
 
 
 def pyproject_distribution_name(root: Path) -> str | None:
@@ -68,10 +76,11 @@ def canonical_hostname(host: object) -> str:
 def desktop_prerequisite_errors(root: Path, desktop: dict) -> list[str]:
     """The local GUI may only claim deployable against the fixed proof set.
 
-    The keys come from REQUIRED_DESKTOP_PREREQUISITES, not from the manifest, and
-    each value must name a file that exists in the tree. Before this, `unproven`
-    was computed from whatever mapping the manifest happened to carry: replacing
-    it with a single evidenced key of any name passed.
+    Keys and values both come from REQUIRED_DESKTOP_PREREQUISITES, not from the
+    manifest. `unproven` used to be computed from whatever mapping the manifest
+    carried, so a single evidenced key of any name passed; then only the key set
+    was fixed, so any existing path — `pyproject.toml`, or `.` — could stand in
+    for the proof it was supposed to name.
     """
     errors: list[str] = []
     prereqs = desktop.get("prerequisites")
@@ -79,10 +88,10 @@ def desktop_prerequisite_errors(root: Path, desktop: dict) -> list[str]:
         return ["desktop-ui: prerequisites must be a mapping of proof keys to evidence"]
 
     declared_keys = set(prereqs)
-    missing = REQUIRED_DESKTOP_PREREQUISITES - declared_keys
+    missing = set(REQUIRED_DESKTOP_PREREQUISITES) - declared_keys
     if missing:
         errors.append("desktop-ui: prerequisites missing required keys: " + ", ".join(sorted(missing)))
-    unknown = declared_keys - REQUIRED_DESKTOP_PREREQUISITES
+    unknown = declared_keys - set(REQUIRED_DESKTOP_PREREQUISITES)
     if unknown:
         errors.append("desktop-ui: prerequisites declare unknown keys: " + ", ".join(sorted(unknown)))
 
@@ -91,14 +100,15 @@ def desktop_prerequisite_errors(root: Path, desktop: dict) -> list[str]:
     if desktop.get("deployable") is not True:
         return errors
 
-    for key in sorted(REQUIRED_DESKTOP_PREREQUISITES & declared_keys):
+    for key in sorted(set(REQUIRED_DESKTOP_PREREQUISITES) & declared_keys):
+        expected = REQUIRED_DESKTOP_PREREQUISITES[key]
         evidence = prereqs[key]
-        if not isinstance(evidence, str) or not evidence.strip():
-            errors.append(f"desktop-ui: deployable=true but {key} has no proof")
-        elif not (root / evidence.strip()).exists():
+        if not isinstance(evidence, str) or evidence.strip() != expected:
             errors.append(
-                f"desktop-ui: {key} points at {evidence.strip()}, which does not exist in the tree"
+                f"desktop-ui: deployable=true but {key} must name {expected}, not {evidence!r}"
             )
+        elif not (root / expected).is_file():
+            errors.append(f"desktop-ui: {key} names {expected}, which is not a file in the tree")
 
     errors.extend(shipping_claim_errors(root, desktop))
     return errors
@@ -116,14 +126,33 @@ def desktop_shell_errors(root: Path, desktop: dict) -> list[str]:
         errors.append("desktop-ui: desktop_shell.decision_record must name an existing ADR")
         return errors
 
-    if shell.get("deployable") is True:
-        text = (root / record).read_text(encoding="utf-8")
-        if not ADR_ACCEPTED_RE.search(text):
-            errors.append(
-                f"desktop-ui: desktop_shell.deployable=true while {record} is not accepted — "
-                "no shell technology has been chosen"
-            )
+    deployable = shell.get("deployable")
+    # A malformed truthy value such as the string "true" is not `is True`, so the
+    # identity check read it as undeployable and skipped the ADR gate entirely.
+    if not isinstance(deployable, bool):
+        return errors + ["desktop-ui: desktop_shell.deployable must be a boolean"]
+
+    if deployable and adr_status(root / record) != "accepted":
+        errors.append(
+            f"desktop-ui: desktop_shell.deployable=true while {record} is not accepted — "
+            "no shell technology has been chosen"
+        )
     return errors
+
+
+def adr_status(path: Path) -> str | None:
+    """The `status` field of the ADR front matter, or None if there is none."""
+    match = FRONT_MATTER_RE.match(path.read_text(encoding="utf-8"))
+    if not match:
+        return None
+    try:
+        front = yaml.safe_load(match.group(1))
+    except yaml.YAMLError:
+        return None
+    if not isinstance(front, dict):
+        return None
+    status = front.get("status")
+    return status.strip().lower() if isinstance(status, str) else None
 
 
 def shipping_claim_errors(root: Path, desktop: dict) -> list[str]:
@@ -145,33 +174,79 @@ def shipping_claim_errors(root: Path, desktop: dict) -> list[str]:
     if not bundled_at:
         errors.append("desktop-ui: ships_as.bundled_at must name the bundled location")
 
+    served_at = str(ships.get("served_at") or "").strip()
+    # The route is fixed by the desktop host contract, which the launcher is
+    # checked against in turn. Without this, the shipping claim could name any
+    # path and stay green.
     try:
-        workflow = (root / RELEASE_WORKFLOW).read_text(encoding="utf-8")
+        host = yaml.safe_load((root / DESKTOP_HOST_CONTRACT).read_text(encoding="utf-8"))
+    except OSError as exc:
+        errors.append(f"cannot read {DESKTOP_HOST_CONTRACT}: {exc}")
+    else:
+        authoritative = ((host or {}).get("endpoint") or {}).get("ui_path")
+        if served_at != authoritative:
+            errors.append(
+                f"desktop-ui: ships_as.served_at {served_at!r} != {DESKTOP_HOST_CONTRACT} "
+                f"endpoint.ui_path {authoritative!r}"
+            )
+
+    try:
+        workflow_steps = release_run_commands(root)
     except OSError as exc:
         return errors + [f"cannot read {RELEASE_WORKFLOW}: {exc}"]
-    if built_from and built_from not in workflow:
+    if built_from and not any(built_from in line for line in workflow_steps):
         errors.append(
             f"desktop-ui: deployable=true but {RELEASE_WORKFLOW} never builds {built_from}"
         )
-    if bundled_at and bundled_at not in workflow:
+    if bundled_at and not any(bundled_at in line for line in workflow_steps):
         errors.append(
             f"desktop-ui: deployable=true but {RELEASE_WORKFLOW} never produces {bundled_at}"
         )
 
+    # The wheel ships the export as package data. Reading the raw text matched a
+    # commented-out entry, which is how a setuptools setting is usually
+    # disabled: parse the table instead.
     try:
-        pyproject = (root / PYPROJECT).read_text(encoding="utf-8")
+        pyproject = tomllib.loads((root / PYPROJECT).read_text(encoding="utf-8"))
     except OSError as exc:
         return errors + [f"cannot read {PYPROJECT}: {exc}"]
-    # The wheel ships the export as package data; without it the GUI is built
-    # in CI and then dropped on the floor. Match the recursive glob, not the
-    # bare name: pyproject also mentions the directory in prose, and a substring
-    # test reads a comment as a shipping declaration.
+    except tomllib.TOMLDecodeError as exc:
+        return errors + [f"{PYPROJECT} is not valid TOML: {exc}"]
+
+    package_data = (
+        pyproject.get("tool", {}).get("setuptools", {}).get("package-data", {})
+    )
+    shipped_globs = [glob for globs in package_data.values() for glob in globs]
     bundled_package_data = bundled_at.rsplit("/", 1)[-1] if bundled_at else ""
-    if bundled_package_data and f"{bundled_package_data}/**/*" not in pyproject:
+    if bundled_package_data and not any(
+        glob.startswith(f"{bundled_package_data}/") for glob in shipped_globs
+    ):
         errors.append(
             f"desktop-ui: deployable=true but {PYPROJECT} does not ship {bundled_package_data}"
         )
     return errors
+
+
+def release_run_commands(root: Path) -> list[str]:
+    """Active command lines of every `run:` step in the release workflow.
+
+    Parsed, not grepped: a commented-out `# python scripts/validate_surfaces.py`
+    still contains the script name, so a text search reported a gate that no
+    longer executes.
+    """
+    workflow = yaml.safe_load((root / RELEASE_WORKFLOW).read_text(encoding="utf-8"))
+    lines: list[str] = []
+    for job in (workflow.get("jobs") or {}).values():
+        for step in (job or {}).get("steps") or []:
+            script = (step or {}).get("run")
+            if not isinstance(script, str):
+                continue
+            lines.extend(
+                line.strip()
+                for line in script.split("\n")
+                if line.strip() and not line.strip().startswith("#")
+            )
+    return lines
 
 
 def validate(root: Path) -> list[str]:

--- a/scripts/validate_surfaces.py
+++ b/scripts/validate_surfaces.py
@@ -48,6 +48,17 @@ REQUIRED_DESKTOP_PREREQUISITES = {
     "perimeter_gate": "scripts/validate_local_surfaces.py",
 }
 DESKTOP_HOST_CONTRACT = Path("contracts/desktop-host.yaml")
+# Where the local GUI is built and bundled. Pinned for the same reason the
+# prerequisite paths are: a substring check let the manifest shorten the claim —
+# `built_from: apps` and `bundled_at: console_dist` both matched the workflow
+# and the package data while naming neither the source nor the bundle.
+EXPECTED_SHIPS_AS = {
+    "built_from": "apps/desktop-ui",
+    "bundled_at": "core/api/console_dist",
+}
+# The one record that can authorise a desktop shell. Without pinning it, the
+# manifest picks whichever accepted ADR happens to exist and authorises itself.
+SHELL_DECISION_RECORD = "docs/decisions/desktop-shell-selection.md"
 # What a shipping local GUI must be true of, read from the files that do the
 # shipping. `deployable: true` is a claim about the release, so it is checked
 # against the release.
@@ -122,9 +133,12 @@ def desktop_shell_errors(root: Path, desktop: dict) -> list[str]:
 
     errors: list[str] = []
     record = shell.get("decision_record")
-    if not isinstance(record, str) or not (root / record).is_file():
-        errors.append("desktop-ui: desktop_shell.decision_record must name an existing ADR")
-        return errors
+    if record != SHELL_DECISION_RECORD:
+        return errors + [
+            f"desktop-ui: desktop_shell.decision_record must be {SHELL_DECISION_RECORD}, not {record!r}"
+        ]
+    if not (root / record).is_file():
+        return errors + [f"desktop-ui: {record} does not exist in the tree"]
 
     deployable = shell.get("deployable")
     # A malformed truthy value such as the string "true" is not `is True`, so the
@@ -132,10 +146,50 @@ def desktop_shell_errors(root: Path, desktop: dict) -> list[str]:
     if not isinstance(deployable, bool):
         return errors + ["desktop-ui: desktop_shell.deployable must be a boolean"]
 
-    if deployable and adr_status(root / record) != "accepted":
+    if not deployable:
+        return errors
+
+    if adr_status(root / record) != "accepted":
         errors.append(
             f"desktop-ui: desktop_shell.deployable=true while {record} is not accepted — "
             "no shell technology has been chosen"
+        )
+
+    # An accepted ADR decides WHICH shell, not that one exists. The flag is a
+    # claim about a shipped artifact, so it is checked against one — the same
+    # way the outer deployable flag is checked against its shipping path.
+    # Nothing packages a desktop application today: the release builds a static
+    # export and puts it in the wheel.
+    errors.extend(shell_packaging_errors(root, shell))
+    return errors
+
+
+def shell_packaging_errors(root: Path, shell: dict) -> list[str]:
+    """A deployable shell must name what builds it and what that produces."""
+    packaged = shell.get("packaged_as")
+    if not isinstance(packaged, dict):
+        return [
+            "desktop-ui: desktop_shell.deployable=true requires a packaged_as block "
+            "naming built_by and artifact — no desktop application is packaged today"
+        ]
+
+    errors: list[str] = []
+    built_by = str(packaged.get("built_by") or "").strip()
+    artifact = str(packaged.get("artifact") or "").strip()
+    if not built_by or not (root / built_by).exists():
+        errors.append(
+            f"desktop-ui: desktop_shell.packaged_as.built_by {built_by!r} does not exist in the tree"
+        )
+    if not artifact:
+        errors.append("desktop-ui: desktop_shell.packaged_as.artifact must name what is produced")
+
+    try:
+        commands = release_run_commands(root)
+    except OSError as exc:
+        return errors + [f"cannot read {RELEASE_WORKFLOW}: {exc}"]
+    if built_by and not any(built_by in line for line in commands):
+        errors.append(
+            f"desktop-ui: desktop_shell.deployable=true but {RELEASE_WORKFLOW} never runs {built_by}"
         )
     return errors
 
@@ -169,10 +223,12 @@ def shipping_claim_errors(root: Path, desktop: dict) -> list[str]:
 
     built_from = str(ships.get("built_from") or "").strip()
     bundled_at = str(ships.get("bundled_at") or "").strip()
-    if not built_from or not (root / built_from).is_dir():
+    for field, expected in EXPECTED_SHIPS_AS.items():
+        declared = str(ships.get(field) or "").strip()
+        if declared != expected:
+            errors.append(f"desktop-ui: ships_as.{field} must be {expected}, not {declared!r}")
+    if built_from and not (root / built_from).is_dir():
         errors.append(f"desktop-ui: ships_as.built_from {built_from!r} is not a directory in the tree")
-    if not bundled_at:
-        errors.append("desktop-ui: ships_as.bundled_at must name the bundled location")
 
     served_at = str(ships.get("served_at") or "").strip()
     # The route is fixed by the desktop host contract, which the launcher is
@@ -216,14 +272,18 @@ def shipping_claim_errors(root: Path, desktop: dict) -> list[str]:
     package_data = (
         pyproject.get("tool", {}).get("setuptools", {}).get("package-data", {})
     )
-    shipped_globs = [glob for globs in package_data.values() for glob in globs]
-    bundled_package_data = bundled_at.rsplit("/", 1)[-1] if bundled_at else ""
-    if bundled_package_data and not any(
-        glob.startswith(f"{bundled_package_data}/") for glob in shipped_globs
-    ):
-        errors.append(
-            f"desktop-ui: deployable=true but {PYPROJECT} does not ship {bundled_package_data}"
-        )
+    # Derived from the bundle path rather than matched loosely: core/api/console_dist
+    # means the `core.api` package must ship globs under `console_dist/`. Scanning
+    # every package's globs would accept the right glob under the wrong package.
+    if bundled_at and "/" in bundled_at:
+        package, _, directory = bundled_at.rpartition("/")
+        package = package.replace("/", ".")
+        globs = package_data.get(package) or []
+        if not any(str(glob).startswith(f"{directory}/") for glob in globs):
+            errors.append(
+                f"desktop-ui: deployable=true but {PYPROJECT} package-data for {package!r} "
+                f"does not ship {directory}"
+            )
     return errors
 
 

--- a/scripts/validate_surfaces.py
+++ b/scripts/validate_surfaces.py
@@ -22,7 +22,11 @@ import yaml
 OWNER_PROJECT = "marvis"
 OWNER_REPO = "emiliomartucci/marvis"
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-REQUIRED_FIELDS = ("surface_id", "owner_project", "owner_repo", "contract_version", "description")
+# Split by type: the first version used one tuple and a `!= 0` escape for the
+# integer field, which made `owner_project: 0` count as present and then skipped
+# the ownership comparison behind a truthiness guard.
+REQUIRED_STRING_FIELDS = ("surface_id", "owner_project", "owner_repo", "description")
+REQUIRED_INT_FIELDS = ("contract_version",)
 # Hostnames owned by other products in the portfolio; no manifest here may claim them.
 FOREIGN_HOSTNAMES = {
     "console.justaskmarvis.com",
@@ -32,12 +36,142 @@ FOREIGN_HOSTNAMES = {
     "app.justaskmarvis.com",
     "api.justaskmarvis.com",
 }
+# The proofs a deployable local GUI owes, fixed here rather than read from the
+# manifest: a gate that lets the audited file decide what it is audited against
+# only certifies whatever it was handed.
+REQUIRED_DESKTOP_PREREQUISITES = frozenset(
+    {"local_gui_characterization", "desktop_host_contract", "perimeter_gate"}
+)
+# What a shipping local GUI must be true of, read from the files that do the
+# shipping. `deployable: true` is a claim about the release, so it is checked
+# against the release.
+RELEASE_WORKFLOW = Path(".github/workflows/release.yml")
+PYPROJECT = Path("pyproject.toml")
+ADR_ACCEPTED_RE = re.compile(r"^status:\s*accepted\s*$", re.IGNORECASE | re.MULTILINE)
 
 
 def pyproject_distribution_name(root: Path) -> str | None:
     text = (root / "pyproject.toml").read_text(encoding="utf-8")
     match = re.search(r'^name\s*=\s*"([^"]+)"', text, re.MULTILINE)
     return match.group(1) if match else None
+
+
+def canonical_hostname(host: object) -> str:
+    """DNS-equivalent form: case-insensitive, optional root dot removed.
+
+    `Console.JustAskMarvis.com` and `console.justaskmarvis.com.` are the same
+    host. A raw membership test read them as two strangers and let both through.
+    """
+    return str(host).strip().rstrip(".").lower()
+
+
+def desktop_prerequisite_errors(root: Path, desktop: dict) -> list[str]:
+    """The local GUI may only claim deployable against the fixed proof set.
+
+    The keys come from REQUIRED_DESKTOP_PREREQUISITES, not from the manifest, and
+    each value must name a file that exists in the tree. Before this, `unproven`
+    was computed from whatever mapping the manifest happened to carry: replacing
+    it with a single evidenced key of any name passed.
+    """
+    errors: list[str] = []
+    prereqs = desktop.get("prerequisites")
+    if not isinstance(prereqs, dict):
+        return ["desktop-ui: prerequisites must be a mapping of proof keys to evidence"]
+
+    declared_keys = set(prereqs)
+    missing = REQUIRED_DESKTOP_PREREQUISITES - declared_keys
+    if missing:
+        errors.append("desktop-ui: prerequisites missing required keys: " + ", ".join(sorted(missing)))
+    unknown = declared_keys - REQUIRED_DESKTOP_PREREQUISITES
+    if unknown:
+        errors.append("desktop-ui: prerequisites declare unknown keys: " + ", ".join(sorted(unknown)))
+
+    errors.extend(desktop_shell_errors(root, desktop))
+
+    if desktop.get("deployable") is not True:
+        return errors
+
+    for key in sorted(REQUIRED_DESKTOP_PREREQUISITES & declared_keys):
+        evidence = prereqs[key]
+        if not isinstance(evidence, str) or not evidence.strip():
+            errors.append(f"desktop-ui: deployable=true but {key} has no proof")
+        elif not (root / evidence.strip()).exists():
+            errors.append(
+                f"desktop-ui: {key} points at {evidence.strip()}, which does not exist in the tree"
+            )
+
+    errors.extend(shipping_claim_errors(root, desktop))
+    return errors
+
+
+def desktop_shell_errors(root: Path, desktop: dict) -> list[str]:
+    """Packaging the GUI as an installed app waits on an accepted ADR."""
+    shell = desktop.get("desktop_shell")
+    if not isinstance(shell, dict):
+        return ["desktop-ui: desktop_shell must be a mapping with deployable and decision_record"]
+
+    errors: list[str] = []
+    record = shell.get("decision_record")
+    if not isinstance(record, str) or not (root / record).is_file():
+        errors.append("desktop-ui: desktop_shell.decision_record must name an existing ADR")
+        return errors
+
+    if shell.get("deployable") is True:
+        text = (root / record).read_text(encoding="utf-8")
+        if not ADR_ACCEPTED_RE.search(text):
+            errors.append(
+                f"desktop-ui: desktop_shell.deployable=true while {record} is not accepted — "
+                "no shell technology has been chosen"
+            )
+    return errors
+
+
+def shipping_claim_errors(root: Path, desktop: dict) -> list[str]:
+    """`deployable: true` must match what the release actually does.
+
+    Anchored to the release workflow and the wheel packaging so the flag states
+    a fact. The opposite drift — the GUI shipping while the manifest denied it —
+    is what left this surface unregistered.
+    """
+    errors: list[str] = []
+    ships = desktop.get("ships_as")
+    if not isinstance(ships, dict):
+        return ["desktop-ui: deployable=true requires a ships_as block"]
+
+    built_from = str(ships.get("built_from") or "").strip()
+    bundled_at = str(ships.get("bundled_at") or "").strip()
+    if not built_from or not (root / built_from).is_dir():
+        errors.append(f"desktop-ui: ships_as.built_from {built_from!r} is not a directory in the tree")
+    if not bundled_at:
+        errors.append("desktop-ui: ships_as.bundled_at must name the bundled location")
+
+    try:
+        workflow = (root / RELEASE_WORKFLOW).read_text(encoding="utf-8")
+    except OSError as exc:
+        return errors + [f"cannot read {RELEASE_WORKFLOW}: {exc}"]
+    if built_from and built_from not in workflow:
+        errors.append(
+            f"desktop-ui: deployable=true but {RELEASE_WORKFLOW} never builds {built_from}"
+        )
+    if bundled_at and bundled_at not in workflow:
+        errors.append(
+            f"desktop-ui: deployable=true but {RELEASE_WORKFLOW} never produces {bundled_at}"
+        )
+
+    try:
+        pyproject = (root / PYPROJECT).read_text(encoding="utf-8")
+    except OSError as exc:
+        return errors + [f"cannot read {PYPROJECT}: {exc}"]
+    # The wheel ships the export as package data; without it the GUI is built
+    # in CI and then dropped on the floor. Match the recursive glob, not the
+    # bare name: pyproject also mentions the directory in prose, and a substring
+    # test reads a comment as a shipping declaration.
+    bundled_package_data = bundled_at.rsplit("/", 1)[-1] if bundled_at else ""
+    if bundled_package_data and f"{bundled_package_data}/**/*" not in pyproject:
+        errors.append(
+            f"desktop-ui: deployable=true but {PYPROJECT} does not ship {bundled_package_data}"
+        )
+    return errors
 
 
 def validate(root: Path) -> list[str]:
@@ -53,46 +187,51 @@ def validate(root: Path) -> list[str]:
         if not isinstance(doc, dict):
             errors.append(f"{where}: not a mapping")
             continue
-        for field in REQUIRED_FIELDS:
-            if not doc.get(field) and doc.get(field) != 0:
-                errors.append(f"{where}: missing required field {field}")
+        for field in REQUIRED_STRING_FIELDS:
+            value = doc.get(field)
+            if not isinstance(value, str) or not value.strip():
+                errors.append(f"{where}: {field} must be a non-empty string")
+        for field in REQUIRED_INT_FIELDS:
+            if not isinstance(doc.get(field), int) or isinstance(doc.get(field), bool):
+                errors.append(f"{where}: {field} must be an integer")
         sid = doc.get("surface_id")
         if sid in manifests:
             errors.append(f"{where}: duplicate surface_id {sid}")
         manifests[sid] = doc
-        if doc.get("owner_project") and doc["owner_project"] != OWNER_PROJECT:
-            errors.append(f"{where}: owner_project {doc['owner_project']} != {OWNER_PROJECT}")
-        if doc.get("owner_repo") and doc["owner_repo"] != OWNER_REPO:
-            errors.append(f"{where}: owner_repo {doc['owner_repo']} != {OWNER_REPO}")
-        if "contract_version" in doc and not isinstance(doc["contract_version"], int):
-            errors.append(f"{where}: contract_version must be an integer")
+        # Compared unconditionally: guarding on truthiness let a falsy value
+        # such as `owner_project: 0` skip the very check it should fail.
+        if doc.get("owner_project") != OWNER_PROJECT:
+            errors.append(f"{where}: owner_project {doc.get('owner_project')!r} != {OWNER_PROJECT}")
+        if doc.get("owner_repo") != OWNER_REPO:
+            errors.append(f"{where}: owner_repo {doc.get('owner_repo')!r} != {OWNER_REPO}")
         for host in doc.get("allowed_hostnames") or []:
-            if host in FOREIGN_HOSTNAMES:
+            if canonical_hostname(host) in FOREIGN_HOSTNAMES:
                 errors.append(f"{where}: hostname {host} is owned by another product")
 
     cli = manifests.get("marvis-cli")
     if cli is None:
         errors.append("marvis-cli manifest missing — the shipped wheel would be unregistered")
     else:
+        # `distribution_name` is what ties this manifest to the wheel that
+        # actually ships. Deleting it used to make the cross-check silent
+        # instead of red, so the registry stayed green while identifying
+        # nothing.
         real_name = pyproject_distribution_name(root)
         declared = cli.get("distribution_name")
-        if real_name and declared and real_name != declared:
+        if not isinstance(declared, str) or not declared.strip():
+            errors.append("marvis-cli: distribution_name must be a non-empty string")
+        elif real_name is None:
+            errors.append("marvis-cli: pyproject.toml declares no distribution name to compare")
+        elif real_name != declared:
             errors.append(
                 f"marvis-cli: distribution_name {declared} != pyproject.toml name {real_name}"
             )
 
     desktop = manifests.get("desktop-ui")
     if desktop is None:
-        errors.append("desktop-ui manifest missing — the future GUI surface must stay declared")
-    elif desktop.get("deployable") is True:
-        prereqs = desktop.get("prerequisites") or {}
-        unproven = [key for key, value in prereqs.items() if value in (None, "")]
-        if not prereqs:
-            errors.append("desktop-ui: deployable=true with no prerequisites declared")
-        if unproven:
-            errors.append(
-                "desktop-ui: deployable=true but prerequisites without proof: " + ", ".join(unproven)
-            )
+        errors.append("desktop-ui manifest missing — the local GUI surface must stay declared")
+    else:
+        errors.extend(desktop_prerequisite_errors(root, desktop))
 
     pin_path = root / "contracts" / "engine-pin.yaml"
     try:
@@ -119,8 +258,8 @@ def main() -> int:
             print(f"  - {error}", file=sys.stderr)
         return 1
     print(
-        "surface registry valid: marvis-cli matches pyproject.toml, "
-        "desktop-ui is fail-closed, engine pin ok"
+        "surface registry valid: marvis-cli matches pyproject.toml, the local GUI "
+        "ships the way it declares, the desktop shell stays gated, engine pin ok"
     )
     return 0
 


### PR DESCRIPTION
Task `5a51e8b7-6f34-4181-bd7b-6ffb0dc3e4d5`.

Codex left six unresolved P2 comments on #41. Verified against `main` before touching anything — all six are real, and all six are in a validator this repo advertises as fail-closed.

## The one that ships

A `v*` tag starts `release.yml` directly. The workflow carrying the registry gate runs on `pull_request` and on push to `main` only, and `release.yml` never invoked `validate_surfaces.py`. **The gate covered the path that reviews and skipped the path that publishes.** All three validators now run on the tag path, before anything is built — with a test asserting the ordering, not just the presence.

## Four guards that read absence as consent

| Hole | What passed |
|---|---|
| Truthiness guards on ownership | `owner_project: 0` — the required-field check exempted `0` explicitly, then both comparisons were skipped because the value is falsy |
| Raw hostname membership | `Console.JustAskMarvis.com`, `console.justaskmarvis.com.` — same host to DNS, strangers to `in` |
| `declared and ...` on the wheel cross-check | deleting `distribution_name` made the check silent instead of red, and the field was not required |
| Self-certified prerequisites | `unproven` was computed from the same manifest that declared which proofs were required, so one evidenced key of any name passed |

Fields are now typed and compared unconditionally, hostnames are canonicalised, `distribution_name` is required, and the prerequisite key set lives in the validator with each value required to name a file that exists.

## The sixth was not a validator bug

`contracts/surfaces/desktop-ui.yaml` declared `deployable: false` and described a desktop shell that does not exist — while the local GUI has been shipping for months: `release.yml` builds it, `pyproject.toml` carries `core/api/console_dist` in the wheel, and `ui_static.py` serves it at `/ui/`. The registry reported green over a real, unregistered surface: exactly the artifact-mismatch class it exists to prevent.

The manifest now states what ships, and `deployable: true` is read against the release workflow and the wheel packaging — a GUI nobody builds, or one the wheel drops, fails the gate. Packaging the GUI as an installed desktop app is a separate flag, refused while `docs/decisions/desktop-shell-selection.md` is still `status: open`. That decision has not been made and the manifest no longer implies it has.

## Proofs

Eleven new red cases, plus a green fixture asserted before every tampering so a red case cannot pass for a reason it never tested. 18 tests in this suite, 37 across all validators.

One of them earned its keep during the work: the first version of the wheel-packaging check matched the bare string `console_dist`, which `pyproject.toml` also mentions in a comment — the tampered fixture stayed green until the check was anchored to the recursive glob.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uvo6XZohWoMG9nKfZVFp3Q)_