### PR TITLE
fix(ci): preserve ancestry and artifact perimeter evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Release-contract tests read the exact Plan B base and prove
+          # ancestry; a shallow clone turns valid evidence into false RED.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/scripts/test_validate_local_surfaces.py
+++ b/scripts/test_validate_local_surfaces.py
@@ -11,9 +11,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from validate_local_surfaces import (  # noqa: E402
+    FRAMEWORK_HTML_ROUTES,
+    declared_routes,
     foreign_routes,
     local_nav_routes,
     validate,
+    validate_built_routes,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -221,6 +224,45 @@ class TestPerimeterIsClosed(unittest.TestCase):
         strangers = set(foreign_routes(REPO_ROOT))
         for route in ("/terminal/", "/settings/users/", "/monitoring/"):
             self.assertNotIn(route, strangers, f"{route} must not live in the local product")
+
+    def test_built_artifact_accepts_owned_settings_and_rejects_foreign_routes(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory(prefix="local-artifact-") as raw:
+            bundle = Path(raw)
+            for route in declared_routes(REPO_ROOT) | FRAMEWORK_HTML_ROUTES:
+                target = (
+                    bundle / "index.html"
+                    if route == "/"
+                    else bundle / route.strip("/") / "index.html"
+                )
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_text("<!doctype html>\n", encoding="utf-8")
+
+            self.assertEqual(validate_built_routes(REPO_ROOT, bundle), [])
+            self.assertTrue((bundle / "settings/llm/index.html").is_file())
+
+            foreign = bundle / "settings/users/index.html"
+            foreign.parent.mkdir(parents=True)
+            foreign.write_text("<!doctype html>\n", encoding="utf-8")
+            errors = validate_built_routes(REPO_ROOT, bundle)
+            self.assertTrue(
+                any(
+                    "/settings/users/" in error and "outside" in error
+                    for error in errors
+                ),
+                errors,
+            )
+
+    def test_built_artifact_rejects_a_missing_declared_route(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="local-artifact-") as raw:
+            bundle = Path(raw)
+            (bundle / "index.html").write_text("<!doctype html>\n", encoding="utf-8")
+            errors = validate_built_routes(REPO_ROOT, bundle)
+            self.assertTrue(
+                any("/universe/" in error and "missing" in error for error in errors),
+                errors,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/test_verify_ci_collection.py
+++ b/scripts/test_verify_ci_collection.py
@@ -6,6 +6,8 @@ import shutil
 import tempfile
 import unittest
 
+import yaml
+
 from run_ci_contract import _DESELECTED_RE
 from verify_ci_collection import (
     CollectionContractError,
@@ -49,6 +51,19 @@ class CICollectionContractTests(unittest.TestCase):
         contract["primary_python"] = "3.11"
         with self.assertRaisesRegex(CollectionContractError, "Python row drift"):
             _workflow(ROOT, contract)
+
+    def test_release_ancestry_job_cannot_return_to_a_shallow_checkout(self) -> None:
+        workflow = yaml.safe_load(
+            (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        )
+        steps = workflow["jobs"]["python-contract"]["steps"]
+        checkout = [
+            step
+            for step in steps
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        ]
+        self.assertEqual(len(checkout), 1)
+        self.assertEqual(checkout[0].get("with", {}).get("fetch-depth"), 0)
 
     def test_desktop_release_build_cannot_leave_ci(self) -> None:
         contract = json.loads(

--- a/scripts/validate_local_surfaces.py
+++ b/scripts/validate_local_surfaces.py
@@ -21,6 +21,7 @@ ship. Pages were never the perimeter: the emitted JavaScript is.
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -39,6 +40,9 @@ SHELL_ROUTES = {"/", "/login/", "/login/sso-callback/", "/welcome/"}
 ROUTE_FILES = {"page.tsx", "layout.tsx", "template.tsx", "error.tsx", "not-found.tsx", "loading.tsx"}
 # Reachable from the toolchain rather than from a route.
 TOOLCHAIN_MODULES = {SRC / "test/setup.ts"}
+# Next emits both 404.html and 404/index.html for the framework fallback. It is
+# not a navigable product surface, but it is expected in every static export.
+FRAMEWORK_HTML_ROUTES = {"/404/"}
 
 IMPORT_RE = re.compile(r"""(?:from\s+|import\s*\(\s*)["']([^"']+)["']""")
 # Anything that puts the user on a route: a plain href, a braced one, a template
@@ -273,19 +277,74 @@ def foreign_routes(root: Path) -> list[str]:
     return sorted(exported_routes(root) - declared_routes(root))
 
 
-def main() -> int:
-    root = (Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()).resolve()
-    errors = validate(root)
+def bundled_routes(bundle: Path) -> set[str]:
+    """Translate every emitted HTML file into its public route."""
+    bundle = bundle.resolve()
+    if not bundle.is_dir():
+        return set()
+    routes: set[str] = set()
+    for page in bundle.rglob("*.html"):
+        relative = page.relative_to(bundle)
+        if relative == Path("index.html"):
+            routes.add("/")
+        elif relative.name == "index.html":
+            routes.add("/" + relative.parent.as_posix().strip("/") + "/")
+        else:
+            routes.add("/" + relative.with_suffix("").as_posix().strip("/") + "/")
+    return routes
+
+
+def validate_built_routes(root: Path, bundle: Path) -> list[str]:
+    """Compare the actual packaged HTML routes with the ratified perimeter."""
+    root = root.resolve()
+    bundle = bundle.resolve()
+    emitted = bundled_routes(bundle)
+    if not bundle.is_dir():
+        return [f"static bundle is missing: {bundle}"]
+    if not emitted:
+        return [f"static bundle contains no HTML routes: {bundle}"]
+
+    required = declared_routes(root)
+    allowed = required | FRAMEWORK_HTML_ROUTES
+    errors = [
+        f"{route}: declared local route missing from the built artifact"
+        for route in sorted(required - emitted)
+    ]
+    errors.extend(
+        f"{route}: built artifact route is outside the local perimeter"
+        for route in sorted(emitted - allowed)
+    )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--bundle",
+        type=Path,
+        help="validate emitted HTML routes in this static bundle",
+    )
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    errors = (
+        validate_built_routes(root, args.bundle)
+        if args.bundle is not None
+        else validate(root)
+    )
     if errors:
         print("local surface perimeter INVALID:", file=sys.stderr)
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
         return 1
 
-    print(
-        "local surface perimeter valid: the shipped source carries the declared "
-        "routes, navigates nowhere else, and holds no module the product cannot reach"
-    )
+    if args.bundle is not None:
+        print("local artifact perimeter valid: emitted HTML matches declared routes")
+    else:
+        print(
+            "local surface perimeter valid: the shipped source carries the declared "
+            "routes, navigates nowhere else, and holds no module the product cannot reach"
+        )
     return 0
 
 


### PR DESCRIPTION
Prerequisite for #53 and Marvis task 736df537-89e8-4f9c-8a87-805c62096360.

- gives the consolidated Python job full Git history so exact Plan B ancestry can be proven
- derives packaged HTML route checks from the ratified local surface perimeter
- preserves the owned /settings/llm/ route while rejecting foreign and missing routes
- adds anti-drift coverage for both boundaries

Verified locally:
- 155/155 scripts tests
- CI collection contract readback green
- focused perimeter and checkout regression suites green

No release, tag, publication, or deploy is included.