### PR TITLE
fix(ci): refresh exact OSS release foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - run: pip install -e ".[dev]"
       - name: Checked test collection (paths, counts, markers, matrices)
         run: python scripts/verify_ci_collection.py
+      - name: Release candidate state (no build or publish)
+        run: python scripts/release_candidate.py state
       - name: Required Python suites (zero unexplained skips)
         run: python scripts/run_ci_contract.py
       - name: Immutable 0.3.8 upgrade and rollback

--- a/contracts/ci/collection-v1.json
+++ b/contracts/ci/collection-v1.json
@@ -4,7 +4,7 @@
   "pytest_suites": [
     {
       "path": "core/api/tests",
-      "minimum_collected": 443,
+      "minimum_collected": 444,
       "allowed_skips": 0,
       "allowed_deselections": 0,
       "required_nodes": [
@@ -29,7 +29,7 @@
     },
     {
       "path": "core/cli/tests",
-      "minimum_collected": 29,
+      "minimum_collected": 32,
       "allowed_skips": 0,
       "allowed_deselections": 0,
       "required_nodes": [
@@ -44,7 +44,7 @@
     {
       "path": "scripts",
       "pattern": "test_*.py",
-      "minimum_collected": 187,
+      "minimum_collected": 209,
       "allowed_skips": 0,
       "required_node_suffixes": [
         "CompatibilityContractTests.test_current_contract_passes",
@@ -53,7 +53,8 @@
         "LocalUpgradeTests.test_synthetic_prior_upgrade_and_rollback",
         "LocalUpgradeTests.test_cli_upgrade_uses_settings_projects_root_without_environment",
         "LocalUpgradeTests.test_runtime_settings_preserve_explicit_projects_root",
-        "ReleaseCandidateTests.test_real_release_candidate_is_invalidated_by_the_source_advance"
+        "ReleaseCandidateTests.test_real_release_candidate_is_invalidated_by_the_source_advance",
+        "ReleaseCandidateTests.test_invalidated_pull_request_skips_every_expensive_release_step"
       ]
     }
   ],
@@ -64,9 +65,10 @@
   "workflow": {
     "file": ".github/workflows/ci.yml",
     "required_job": "python-contract",
-    "required_run_fragments": [
+    "required_run_lines": [
       "pip install -e \".[dev]\"",
       "python scripts/verify_ci_collection.py",
+      "python scripts/release_candidate.py state",
       "python scripts/run_ci_contract.py",
       "python scripts/verify_local_upgrade.py --download --version 0.3.8",
       "python scripts/verify_public_claims.py"

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -537,11 +537,15 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_manifest_hashes_only_the_post_foundation_release_delta(self) -> None:
         policy = self.policy()
-        with self.active_candidate_for_unit_test(), tempfile.TemporaryDirectory(
-            prefix="release-foundation-manifest-"
-        ) as raw:
+        shared_source = candidate._shared_source_coordinates(ROOT, policy)
+        state = candidate._candidate_state(policy, shared_source=shared_source)
+        with tempfile.TemporaryDirectory(prefix="release-foundation-manifest-") as raw:
             dist = Path(raw) / "dist"
             self.write_release_artifacts(dist)
+            if state["status"] == "invalidated":
+                with self.assertRaisesRegex(candidate.ReleasePolicyError, "invalidated"):
+                    candidate.build_manifest(ROOT, dist)
+                return
             manifest = candidate.build_manifest(ROOT, dist)
         expected_delta = candidate._git(
             ROOT,

--- a/scripts/test_verify_ci_collection.py
+++ b/scripts/test_verify_ci_collection.py
@@ -23,10 +23,10 @@ ROOT = Path(__file__).resolve().parents[1]
 class CICollectionContractTests(unittest.TestCase):
     def test_current_collection_and_workflows_pass(self) -> None:
         result = verify(ROOT)
-        # 416 API + 29 CLI tests from a clean checkout.  Keep this independent
+        # 444 API + 32 CLI tests from a clean checkout. Keep this independent
         # from generated Console assets and other local build by-products.
-        self.assertGreaterEqual(result["pytest_collected"], 445)
-        self.assertGreaterEqual(result["unittest_collected"], 128)
+        self.assertGreaterEqual(result["pytest_collected"], 476)
+        self.assertGreaterEqual(result["unittest_collected"], 209)
 
     def test_lowered_collection_floor_is_not_a_bypass(self) -> None:
         with tempfile.TemporaryDirectory(prefix="marvis-ci-contract-") as raw:
@@ -51,6 +51,24 @@ class CICollectionContractTests(unittest.TestCase):
         contract["primary_python"] = "3.11"
         with self.assertRaisesRegex(CollectionContractError, "Python row drift"):
             _workflow(ROOT, contract)
+
+    def test_echoed_primary_release_state_is_not_a_gate(self) -> None:
+        contract = json.loads(
+            (ROOT / "contracts/ci/collection-v1.json").read_text(encoding="utf-8")
+        )
+        with tempfile.TemporaryDirectory(prefix="marvis-primary-ci-") as raw:
+            root = Path(raw)
+            shutil.copytree(ROOT / ".github", root / ".github")
+            workflow = root / ".github/workflows/ci.yml"
+            workflow.write_text(
+                workflow.read_text(encoding="utf-8").replace(
+                    "run: python scripts/release_candidate.py state",
+                    "run: echo python scripts/release_candidate.py state",
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(CollectionContractError, "CI run line missing"):
+                _workflow(root, contract)
 
     def test_release_ancestry_job_cannot_return_to_a_shallow_checkout(self) -> None:
         workflow = yaml.safe_load(

--- a/scripts/verify_ci_collection.py
+++ b/scripts/verify_ci_collection.py
@@ -86,12 +86,16 @@ def _workflow(root: Path, contract: dict[str, Any]) -> None:
     if not isinstance(jobs, dict) or spec["required_job"] not in jobs:
         raise CollectionContractError("required Python CI job missing")
     steps = jobs[spec["required_job"]].get("steps", [])
-    commands = "\n".join(
-        str(step.get("run", "")) for step in steps if isinstance(step, dict)
-    )
-    for fragment in spec["required_run_fragments"]:
-        if fragment not in commands:
-            raise CollectionContractError(f"CI run fragment missing: {fragment}")
+    command_lines = {
+        line.strip()
+        for step in steps
+        if isinstance(step, dict)
+        for line in str(step.get("run", "")).splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+    for line in spec["required_run_lines"]:
+        if line not in command_lines:
+            raise CollectionContractError(f"CI run line missing: {line}")
     setup_python = [
         step.get("with", {}).get("python-version")
         for step in steps


### PR DESCRIPTION
Marvis task: 399c22cf-0081-4342-bfbb-a83eedcba775

Refreshes the Plan C CI evidence foundation from exact merged Plan B base 1e8f3977bd1085e358c34e4b08bdcca058130757.

Final candidate: 110317349c3f650cd3043b82080bfe991edcf0ee

Changes:
- freeze the observed collection floors at 444 API, 32 CLI and 209 script tests;
- require the invalidated-candidate minute guard test;
- require exact CI command lines, so an echoed command is not accepted as a gate;
- read the release candidate state inside the existing Python job;
- make manifest testing fail closed during the intentionally invalidated foundation transition.

Local verification after the final commit:
- full checked Python contract: 444 + 32 + 209 green;
- exact collection contract and 53 release tests: green;
- 0.3.8 upgrade and rollback: green;
- public claims, surface registry, local GUI perimeter and desktop host: green;
- candidate state remains invalidated pending the separate exact-coordinate refresh.

The first CI attempt exposed the transitional manifest assertion before any costly release build; this final commit fixes that cause. No manual rerun was requested.

No new Actions job, package build, workflow dispatch, tag, release, PyPI publication, deploy, or Hosted change.