### PR TITLE
release(oss): bind candidate to PR #56 foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ No changes yet.
 ## [0.4.1] - candidate
 
 Security and provenance refresh based on the exact merged Plan B product base
-and the separately pinned CI evidence foundation from PR #54. The release
+and the separately pinned CI evidence foundation from PR #56. The release
 keeps the local CLI, MCP, hooks and packaged GUI contracts while updating the
 shared engine and its regression coverage.
 

--- a/contracts/ci/collection-v1.json
+++ b/contracts/ci/collection-v1.json
@@ -53,7 +53,7 @@
         "LocalUpgradeTests.test_synthetic_prior_upgrade_and_rollback",
         "LocalUpgradeTests.test_cli_upgrade_uses_settings_projects_root_without_environment",
         "LocalUpgradeTests.test_runtime_settings_preserve_explicit_projects_root",
-        "ReleaseCandidateTests.test_real_release_candidate_is_invalidated_by_the_source_advance",
+        "ReleaseCandidateTests.test_real_release_candidate_static_policy",
         "ReleaseCandidateTests.test_invalidated_pull_request_skips_every_expensive_release_step"
       ]
     }

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -3,17 +3,18 @@
   "package": "marvisx-cli",
   "repository": "emiliomartucci/marvis",
   "release_branch": "main",
-  "plan_b_product_base_sha": "c1a4790100e228a8588e049fbd31233c6da73f88",
+  "plan_b_product_base_sha": "1e8f3977bd1085e358c34e4b08bdcca058130757",
   "release_foundation": {
     "repository": "emiliomartucci/marvis",
-    "pull_request": 54,
-    "candidate_sha": "2da56bfaff8ea6e0c8744761e40268750d2eeae3",
-    "merge_sha": "5a37295a084c990c63e824e2019108ee984684aa",
+    "pull_request": 56,
+    "candidate_sha": "110317349c3f650cd3043b82080bfe991edcf0ee",
+    "merge_sha": "bab84da1a4c104b6ab273dc5166752c97dac5a1b",
     "expected_changed_paths": [
       ".github/workflows/ci.yml",
-      "scripts/test_validate_local_surfaces.py",
+      "contracts/ci/collection-v1.json",
+      "scripts/test_release_candidate.py",
       "scripts/test_verify_ci_collection.py",
-      "scripts/validate_local_surfaces.py"
+      "scripts/verify_ci_collection.py"
     ]
   },
   "shared_source": {
@@ -24,10 +25,7 @@
     "engine_pin": "contracts/engine-pin.yaml"
   },
   "candidate_state": {
-    "status": "invalidated",
-    "reason": "shared_source_advanced_after_release_foundation",
-    "invalidated_by_shared_source_sha": "64e96cb7e90292816296750906db68ec81c4a37e",
-    "required_next_gate": "merge_product_projection_then_refresh_release_foundation"
+    "status": "active"
   },
   "candidate_version": "0.4.1",
   "candidate_tag": "v0.4.1",

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -10,16 +10,13 @@ The current shared source is MarvisX PR `#316`: reviewed candidate
 coordinates to the local engine pin and verifies the GitHub readback before
 publication can proceed.
 
-This source advance happened after the previous release foundation. The 0.4.1
-candidate is therefore fail-closed and cannot build, tag or publish until the
-product projection merges and a separate release-foundation refresh binds its
-exact Marvis merge SHA.
-
-The release also preserves the exact Plan B product base while pinning Marvis
-PR `#54` as a separate CI evidence foundation: candidate
-`2da56bfaff8ea6e0c8744761e40268750d2eeae3`, merge
-`5a37295a084c990c63e824e2019108ee984684aa`. Only the release-specific delta
-after that merge is admitted by the unchanged release allowlist.
+The exact Plan B product projection is Marvis PR `#55`: final candidate
+`39d7299ae26824639e8004e6dc29c3accc72775c`, merged as
+`1e8f3977bd1085e358c34e4b08bdcca058130757`. The separate CI evidence
+foundation is Marvis PR `#56`: final candidate
+`110317349c3f650cd3043b82080bfe991edcf0ee`, merged as
+`bab84da1a4c104b6ab273dc5166752c97dac5a1b`. Only the release-specific delta
+after that foundation is admitted by the unchanged release allowlist.
 
 Highlights:
 
@@ -35,11 +32,10 @@ Highlights:
 License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
-Publication status: invalidated candidate. No tag, GitHub Release or PyPI file
-exists, and all release commands refuse to proceed until the exact product
-base is refreshed before the separate owner approval and immutable publication
-gates.
-After the restricted release-source PR merges, the explicit `workflow_dispatch`
+Publication status: active source candidate, not a published release. No tag,
+GitHub Release or PyPI file exists. The exact product and foundation pins are
+now satisfied; owner approval and immutable publication gates remain open.
+After this restricted release-source PR merges, the explicit `workflow_dispatch`
 preflight must pass at the exact remote `main` head before a tag is created. It
 fails before the expensive build if the version exists, the protected
 environment drifts, or either external owner receipt is absent or stale.

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -87,27 +87,46 @@ class ReleaseCandidateTests(unittest.TestCase):
         }
         return trusted, watchdog
 
-    def test_real_release_candidate_is_invalidated_by_the_source_advance(self) -> None:
-        policy = self.policy()
-        shared_source = candidate._shared_source_coordinates(ROOT, policy)
-        state = candidate._candidate_state(policy, shared_source=shared_source)
-        self.assertEqual(state["status"], "invalidated")
+    def test_real_release_candidate_static_policy(self) -> None:
+        report = candidate.validate_static(ROOT)
+        self.assertEqual(report["status"], "static_green_external_gates_open")
+        self.assertEqual(report["version"], "0.4.1")
+        self.assertEqual(report["release_branch"], "main")
         self.assertEqual(
-            state["invalidated_by_shared_source_sha"],
+            report["product_base_sha"],
+            "1e8f3977bd1085e358c34e4b08bdcca058130757",
+        )
+        self.assertEqual(
+            report["release_foundation"]["candidate_sha"],
+            "110317349c3f650cd3043b82080bfe991edcf0ee",
+        )
+        self.assertEqual(
+            report["release_foundation"]["merge_sha"],
+            "bab84da1a4c104b6ab273dc5166752c97dac5a1b",
+        )
+        self.assertEqual(
+            report["release_foundation"]["changed_paths"],
+            self.policy()["release_foundation"]["expected_changed_paths"],
+        )
+        self.assertEqual(
+            report["shared_source"]["candidate_sha"],
+            "4efd50cbe6b70c0febdd6b9ea0b812aa7d71569d",
+        )
+        self.assertEqual(
+            report["shared_source"]["merge_sha"],
             "64e96cb7e90292816296750906db68ec81c4a37e",
         )
-        with self.assertRaisesRegex(candidate.ReleasePolicyError, "invalidated"):
-            candidate.validate_static(ROOT)
-        report = candidate.candidate_state_report(ROOT)
-        self.assertEqual(report["status"], "invalidated")
-        self.assertEqual(
-            report["shared_source_sha"],
-            "64e96cb7e90292816296750906db68ec81c4a37e",
-        )
+        self.assertEqual(len(report["action_pins"]), 5)
+        self.assertEqual(candidate.candidate_state_report(ROOT)["status"], "active")
 
     def test_candidate_invalidation_cannot_name_an_unrelated_source(self) -> None:
         policy = self.policy()
-        policy["candidate_state"]["invalidated_by_shared_source_sha"] = "0" * 40
+        policy["candidate_state"] = {
+            "status": "invalidated",
+            "reason": "shared_source_advanced_after_release_foundation",
+            "invalidated_by_shared_source_sha": "0" * 40,
+            "required_next_gate": "merge_product_projection_then_refresh_release_foundation",
+        }
         shared_source = candidate._shared_source_coordinates(ROOT, policy)
         with self.assertRaisesRegex(
             candidate.ReleasePolicyError, "invalidation evidence is inconsistent"
@@ -116,7 +135,7 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_active_candidate_cannot_keep_stale_invalidation_evidence(self) -> None:
         policy = self.policy()
-        policy["candidate_state"]["status"] = "active"
+        policy["candidate_state"]["reason"] = "stale"
         shared_source = candidate._shared_source_coordinates(ROOT, policy)
         with self.assertRaisesRegex(
             candidate.ReleasePolicyError, "active candidate state contains stale evidence"
@@ -242,7 +261,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         expected = policy["release_foundation"]
         pull = {
             "state": "closed",
-            "merged_at": "2026-08-29T13:06:26Z",
+            "merged_at": "2026-08-29T15:01:11Z",
             "head": {"sha": expected["candidate_sha"]},
             "merge_commit_sha": expected["merge_sha"],
         }
@@ -250,7 +269,7 @@ class ReleaseCandidateTests(unittest.TestCase):
             report = candidate._release_foundation_readback(
                 ROOT, policy, token="masked", api_url="https://api.example"
             )
-        self.assertEqual(report["pull_request"], 54)
+        self.assertEqual(report["pull_request"], 56)
         self.assertEqual(
             report["changed_paths"], expected["expected_changed_paths"]
         )


### PR DESCRIPTION
Marvis task: a3c17f48-05e7-4520-aa3f-dbf098eac4ff

Binds the restricted Plan C source candidate to exact merged coordinates:
- Plan B product base / PR #55 merge: 1e8f3977bd1085e358c34e4b08bdcca058130757
- release-foundation PR #56 candidate: 110317349c3f650cd3043b82080bfe991edcf0ee
- release-foundation PR #56 merge: bab84da1a4c104b6ab273dc5166752c97dac5a1b
- shared MarvisX PR #316 merge: 64e96cb7e90292816296750906db68ec81c4a37e
- this candidate: 27de3cd207fcffeb8af4ce971a746fba3a7d7781

The exact release-only delta is five files: policy, collection binding, release tests, changelog and 0.4.1 notes. Candidate state becomes active only for source/build validation.

Local verification after commit:
- static release gate: green with exact five-file delta;
- 53 release tests: green;
- full checked Python contract: 444 API + 32 CLI + 209 script tests green;
- exact collection contract: green.

Still blocked by design:
- trusted-publisher owner readback;
- external approval watchdog;
- exact-main workflow dispatch;
- tag creation and publication authorization.

No workflow dispatch, tag, GitHub Release, PyPI publication, deploy, or Hosted change is performed.