### PR TITLE
fix(release): bind watchdog receipts to source

### DIFF
--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -8,7 +8,7 @@ publisher, and an external 24-hour approval-watchdog receipt before upload.
 from __future__ import annotations
 
 import argparse
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from email.parser import Parser
 import hashlib
 import importlib.metadata
@@ -592,11 +592,14 @@ def _external_receipts(
 def _strict_external_receipts(
     policy: dict[str, Any],
     *,
+    release_source_sha: str,
     now: datetime | None = None,
     trusted_publisher_receipt: dict[str, Any] | None = None,
     approval_watchdog_receipt: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    if not SHA40.fullmatch(release_source_sha):
+        raise ReleasePolicyError("release source SHA for external receipts is invalid")
     if trusted_publisher_receipt is None or approval_watchdog_receipt is None:
         trusted_publisher_receipt, approval_watchdog_receipt = _external_receipts()
     readback = trusted_publisher_receipt
@@ -620,12 +623,45 @@ def _strict_external_receipts(
     observed_watchdog = {key: watchdog.get(key) for key in expected_watchdog}
     if observed_watchdog != expected_watchdog:
         raise ReleasePolicyError("approval watchdog receipt coordinates do not match policy")
+    if watchdog.get("target_head_sha") != release_source_sha:
+        raise ReleasePolicyError("approval watchdog targets another release source")
     watchdog_verified_at = _parse_time(str(watchdog.get("verified_at") or ""))
     watchdog_age = (current - watchdog_verified_at).total_seconds()
     if watchdog_age < 0 or watchdog_age > 24 * 3600:
         raise ReleasePolicyError("approval watchdog receipt is stale")
     if not watchdog.get("verified_by"):
         raise ReleasePolicyError("approval watchdog receipt has no verifier")
+    active_until = _parse_time(str(watchdog.get("active_until") or ""))
+    required_until = current + timedelta(
+        hours=int(policy["approval_deadline_hours"])
+    )
+    if active_until < required_until:
+        raise ReleasePolicyError(
+            "approval watchdog does not cover the full approval window"
+        )
+    worker_version = watchdog.get("worker_version")
+    if not isinstance(worker_version, dict):
+        raise ReleasePolicyError("approval watchdog has no Worker version identity")
+    worker_version_id = worker_version.get("id")
+    worker_version_timestamp = worker_version.get("timestamp")
+    if not isinstance(worker_version_id, str) or not worker_version_id.strip():
+        raise ReleasePolicyError("approval watchdog Worker version id is invalid")
+    if not isinstance(worker_version_timestamp, str):
+        raise ReleasePolicyError("approval watchdog Worker version timestamp is invalid")
+    _parse_time(worker_version_timestamp)
+    expected_receipt_prefix = (
+        "cloudflare-worker://marvis-oss-release-watchdog-041/"
+        f"{worker_version_id}/"
+    )
+    receipt_ref = str(watchdog["receipt_ref"])
+    receipt_digest = receipt_ref.removeprefix(expected_receipt_prefix)
+    if (
+        not receipt_ref.startswith(expected_receipt_prefix)
+        or not SHA256.fullmatch(receipt_digest)
+    ):
+        raise ReleasePolicyError(
+            "approval watchdog receipt does not bind its Worker version"
+        )
     summaries = {
         "trusted_publisher": {
             "sha256": _sha_bytes(_canonical(readback)),
@@ -637,7 +673,10 @@ def _strict_external_receipts(
             "sha256": _sha_bytes(_canonical(watchdog)),
             "verified_at": watchdog["verified_at"],
             "verified_by": watchdog["verified_by"],
-            "receipt_ref": watchdog["receipt_ref"],
+            "receipt_ref": receipt_ref,
+            "target_head_sha": watchdog["target_head_sha"],
+            "active_until": watchdog["active_until"],
+            "worker_version": worker_version,
         },
     }
     return summaries
@@ -1115,7 +1154,9 @@ def preflight(
     report = validate_static(root)
     policy = load_policy(root)
     _require_release_controls_committed(root, report["release_source_sha"])
-    external_receipts = _strict_external_receipts(policy)
+    external_receipts = _strict_external_receipts(
+        policy, release_source_sha=report["release_source_sha"]
+    )
     shared_source = _shared_source_readback(
         root, policy, token=token, api_url=api_url
     )
@@ -1174,7 +1215,9 @@ def tag_preflight(
     report = validate_static(root, tag_build=True)
     policy = load_policy(root)
     _require_release_controls_committed(root, report["release_source_sha"])
-    external_receipts = _strict_external_receipts(policy)
+    external_receipts = _strict_external_receipts(
+        policy, release_source_sha=report["release_source_sha"]
+    )
     shared_source = _shared_source_readback(
         root, policy, token=token, api_url=api_url
     )
@@ -1231,7 +1274,9 @@ def pretag(root: Path, *, token: str, api_url: str = "https://api.github.com") -
     report = validate_static(root, tag_build=True)
     policy = load_policy(root)
     _require_release_controls_committed(root, report["release_source_sha"])
-    external_receipts = _strict_external_receipts(policy)
+    external_receipts = _strict_external_receipts(
+        policy, release_source_sha=report["release_source_sha"]
+    )
     shared_source = _shared_source_readback(
         root, policy, token=token, api_url=api_url
     )
@@ -1375,7 +1420,7 @@ def build_manifest(
         or os.environ.get(_APPROVAL_WATCHDOG_RECEIPT_ENV)
     )
     external_receipts = (
-        _strict_external_receipts(policy)
+        _strict_external_receipts(policy, release_source_sha=resolved_head)
         if tag_exists or receipt_env_present
         else None
     )
@@ -1778,7 +1823,9 @@ def build_acceptance_receipt(
     verify_manifest(root, github_dist / manifest_path.name, github_dist)
     registry = registry_verify(manifest_path, attempts=1, delay_seconds=0)
     policy = load_policy(root)
-    external_receipts = _strict_external_receipts(policy, now=now)
+    external_receipts = _strict_external_receipts(
+        policy, release_source_sha=source_sha, now=now
+    )
     shared_source = _shared_source_readback(
         root, policy, token=token, api_url=api_url
     )
@@ -1880,9 +1927,14 @@ def publish_window(
     now: datetime | None = None,
     api_url: str = "https://api.github.com",
 ) -> dict[str, Any]:
-    policy = load_policy(root)
-    external_receipts = _strict_external_receipts(policy, now=now)
     manifest = _validated_manifest(manifest_path)
+    source_sha = str(manifest.get("release_source_sha") or "")
+    if not SHA40.fullmatch(source_sha):
+        raise ReleasePolicyError("release manifest source is invalid")
+    policy = load_policy(root)
+    external_receipts = _strict_external_receipts(
+        policy, release_source_sha=source_sha, now=now
+    )
     shared_source = _shared_source_readback(
         root, policy, token=token, api_url=api_url
     )

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -25,6 +25,8 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 class ReleaseCandidateTests(unittest.TestCase):
+    RELEASE_SOURCE_SHA = "a" * 40
+
     def policy(self) -> dict:
         return copy.deepcopy(candidate.load_policy(ROOT))
 
@@ -75,7 +77,10 @@ class ReleaseCandidateTests(unittest.TestCase):
             "schema": candidate.EXTERNAL_RECEIPT_SCHEMA,
             "kind": "approval_watchdog",
             "status": "ready",
-            "receipt_ref": "ledger:receipt",
+            "receipt_ref": (
+                "cloudflare-worker://marvis-oss-release-watchdog-041/"
+                f"worker-version-123/{'d' * 64}"
+            ),
             "verified_at": now.isoformat(),
             "verified_by": "owner",
             "repository": policy["repository"],
@@ -84,6 +89,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             "candidate_tag": policy["candidate_tag"],
             "approval_deadline_hours": policy["approval_deadline_hours"],
             "late_approval_upload_guard": True,
+            "target_head_sha": self.RELEASE_SOURCE_SHA,
+            "active_until": (now + timedelta(hours=49)).isoformat(),
+            "worker_version": {
+                "id": "worker-version-123",
+                "tag": "release-watchdog-041",
+                "timestamp": now.isoformat(),
+            },
         }
         return trusted, watchdog
 
@@ -500,7 +512,9 @@ class ReleaseCandidateTests(unittest.TestCase):
         with mock.patch.dict(candidate.os.environ, {}, clear=True), self.assertRaisesRegex(
             candidate.ReleasePolicyError, "receipt is absent"
         ):
-            candidate._strict_external_receipts(self.policy())
+            candidate._strict_external_receipts(
+                self.policy(), release_source_sha=self.RELEASE_SOURCE_SHA
+            )
 
     def test_external_receipt_expires_after_24_hours(self) -> None:
         now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
@@ -509,6 +523,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "stale"):
             candidate._strict_external_receipts(
                 policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
                 now=now,
                 trusted_publisher_receipt=trusted,
                 approval_watchdog_receipt=watchdog,
@@ -520,6 +535,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         trusted, watchdog = self.external_receipts(now - timedelta(minutes=5), policy)
         summaries = candidate._strict_external_receipts(
             policy,
+            release_source_sha=self.RELEASE_SOURCE_SHA,
             now=now,
             trusted_publisher_receipt=trusted,
             approval_watchdog_receipt=watchdog,
@@ -536,6 +552,66 @@ class ReleaseCandidateTests(unittest.TestCase):
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "coordinates"):
             candidate._strict_external_receipts(
                 policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_for_another_release_source_is_rejected(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog["target_head_sha"] = "b" * 40
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "another release source"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_must_cover_the_full_remaining_approval_window(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog["active_until"] = (now + timedelta(hours=23, minutes=59)).isoformat()
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "full approval window"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_receipt_requires_worker_version_identity(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog.pop("worker_version")
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "Worker version identity"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_receipt_ref_binds_worker_version(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog["receipt_ref"] = (
+            "cloudflare-worker://marvis-oss-release-watchdog-041/"
+            f"another-worker/{'e' * 64}"
+        )
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "bind its Worker version"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
                 now=now,
                 trusted_publisher_receipt=trusted,
                 approval_watchdog_receipt=watchdog,


### PR DESCRIPTION
## Summary
- bind every external watchdog receipt to the exact reviewed release commit
- require watchdog coverage for the full remaining approval window
- preserve the Cloud Worker version identity in the immutable release evidence

## Verification
- Python 3.13 release-contract suite: 57/57 green
- diff and credential-pattern checks: green

Marvis task: 360468dd-acda-4579-a08e-5de3b577e29f
Cloud dependency: emiliomartucci/marvisx-cloud#49

This PR does not tag, publish to PyPI, deploy Cloud, or authorize a release.