### PR TITLE
fix(release): require watchdog write proof

### DIFF
--- a/.github/workflows/watchdog-canary.yml
+++ b/.github/workflows/watchdog-canary.yml
@@ -1,0 +1,47 @@
+name: OSS release watchdog write-authority canary
+
+run-name: watchdog-canary-${{ inputs.mode }}-${{ inputs.nonce }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Exact write capability to prove
+        required: true
+        type: choice
+        options:
+          - reject-pending-deployment
+          - cancel-workflow-run
+      nonce:
+        description: Operator-generated correlation id
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: watchdog-write-authority-${{ inputs.mode }}-${{ inputs.nonce }}
+  cancel-in-progress: false
+
+jobs:
+  reject-pending-deployment:
+    if: inputs.mode == 'reject-pending-deployment'
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    environment: pypi
+    steps:
+      - name: Fail if the protected deployment is approved instead of rejected
+        run: exit 1
+
+  cancel-workflow-run:
+    if: inputs.mode == 'cancel-workflow-run'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Wait for the watchdog token to cancel this exact run
+        run: |
+          for attempt in {1..24}; do
+            sleep 5
+          done
+          exit 1

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -33,6 +33,7 @@
   "approval_deadline_hours": 24,
   "allowed_release_delta": [
     ".github/workflows/release.yml",
+    ".github/workflows/watchdog-canary.yml",
     "CHANGELOG.md",
     "contracts/ci/collection-v1.json",
     "contracts/release/",
@@ -62,6 +63,7 @@
     "workflow": "release.yml",
     "environment": "pypi",
     "candidate_tag": "v0.4.1",
+    "write_authority_canary_workflow": "watchdog-canary.yml",
     "approval_deadline_hours": 24,
     "late_approval_upload_guard": true
   },

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -41,6 +41,7 @@ POLICY_SCHEMA = "marvis-public-release-policy/v1"
 MANIFEST_SCHEMA = "marvis-public-release-manifest/v1"
 ACCEPTANCE_SCHEMA = "marvis-public-release-acceptance/v1"
 EXTERNAL_RECEIPT_SCHEMA = "marvis-external-release-receipt/v1"
+WATCHDOG_WRITE_AUTHORITY_SCHEMA = "marvis-watchdog-write-authority/v1"
 POLICY_PATH = Path("contracts/release/public-release-v1.json")
 WORKFLOW_PATH = Path(".github/workflows/release.yml")
 SHA40 = re.compile(r"^[0-9a-f]{40}$")
@@ -631,6 +632,73 @@ def _strict_external_receipts(
         raise ReleasePolicyError("approval watchdog receipt is stale")
     if not watchdog.get("verified_by"):
         raise ReleasePolicyError("approval watchdog receipt has no verifier")
+    write_authority = watchdog.get("write_authority")
+    if not isinstance(write_authority, dict):
+        raise ReleasePolicyError("approval watchdog has no write-authority proof")
+    expected_canary_workflow = expected_watchdog.get(
+        "write_authority_canary_workflow"
+    )
+    expected_verifier = (
+        f"github-user:{policy['github_environment']['required_reviewer_login']}"
+    )
+    expected_proof_coordinates = {
+        "schema": WATCHDOG_WRITE_AUTHORITY_SCHEMA,
+        "status": "verified",
+        "repository": expected_watchdog.get("repository"),
+        "canary_workflow": expected_canary_workflow,
+        "environment": expected_watchdog.get("environment"),
+        "target_head_sha": release_source_sha,
+        "verified_by": expected_verifier,
+    }
+    observed_proof_coordinates = {
+        key: write_authority.get(key) for key in expected_proof_coordinates
+    }
+    if observed_proof_coordinates != expected_proof_coordinates:
+        raise ReleasePolicyError("watchdog write-authority coordinates do not match")
+    proof_verified_at = _parse_time(
+        str(write_authority.get("verified_at") or "")
+    )
+    proof_age = (current - proof_verified_at).total_seconds()
+    if (
+        proof_age < 0
+        or proof_age > 24 * 3600
+        or proof_verified_at > watchdog_verified_at
+    ):
+        raise ReleasePolicyError("watchdog write-authority proof is stale or unordered")
+    capabilities = write_authority.get("capabilities")
+    if not isinstance(capabilities, dict) or set(capabilities) != {
+        "reject_pending_deployment",
+        "cancel_workflow_run",
+    }:
+        raise ReleasePolicyError("watchdog write-authority capabilities are incomplete")
+    reject_proof = capabilities["reject_pending_deployment"]
+    cancel_proof = capabilities["cancel_workflow_run"]
+    if not isinstance(reject_proof, dict) or not isinstance(cancel_proof, dict):
+        raise ReleasePolicyError("watchdog write-authority capability proof is invalid")
+    reject_run_id = reject_proof.get("run_id")
+    cancel_run_id = cancel_proof.get("run_id")
+    if any(
+        isinstance(run_id, bool)
+        or not isinstance(run_id, int)
+        or run_id <= 0
+        for run_id in (reject_run_id, cancel_run_id)
+    ) or reject_run_id == cancel_run_id:
+        raise ReleasePolicyError("watchdog write-authority run identity is invalid")
+    expected_run_url = (
+        f"https://github.com/{expected_watchdog.get('repository')}/actions/runs/"
+    )
+    if (
+        reject_proof.get("status") != "verified"
+        or reject_proof.get("observed_state") != "rejected"
+        or reject_proof.get("run_url") != f"{expected_run_url}{reject_run_id}"
+        or cancel_proof.get("status") != "verified"
+        or cancel_proof.get("observed_conclusion") != "cancelled"
+        or cancel_proof.get("run_url") != f"{expected_run_url}{cancel_run_id}"
+    ):
+        raise ReleasePolicyError("watchdog write-authority readback is invalid")
+    write_authority_sha256 = _sha_bytes(_canonical(write_authority))
+    if watchdog.get("write_authority_sha256") != write_authority_sha256:
+        raise ReleasePolicyError("watchdog write-authority digest does not match")
     active_until = _parse_time(str(watchdog.get("active_until") or ""))
     required_until = current + timedelta(
         hours=int(policy["approval_deadline_hours"])
@@ -677,6 +745,7 @@ def _strict_external_receipts(
             "target_head_sha": watchdog["target_head_sha"],
             "active_until": watchdog["active_until"],
             "worker_version": worker_version,
+            "write_authority_sha256": write_authority_sha256,
         },
     }
     return summaries

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -635,6 +635,20 @@ def _strict_external_receipts(
     write_authority = watchdog.get("write_authority")
     if not isinstance(write_authority, dict):
         raise ReleasePolicyError("approval watchdog has no write-authority proof")
+    if set(write_authority) != {
+        "schema",
+        "status",
+        "repository",
+        "canary_workflow",
+        "environment",
+        "target_head_sha",
+        "nonce",
+        "verified_at",
+        "verified_by",
+        "capabilities",
+        "worker_attestation",
+    }:
+        raise ReleasePolicyError("watchdog write-authority proof shape is invalid")
     expected_canary_workflow = expected_watchdog.get(
         "write_authority_canary_workflow"
     )
@@ -655,6 +669,11 @@ def _strict_external_receipts(
     }
     if observed_proof_coordinates != expected_proof_coordinates:
         raise ReleasePolicyError("watchdog write-authority coordinates do not match")
+    proof_nonce = write_authority.get("nonce")
+    if not isinstance(proof_nonce, str) or re.fullmatch(
+        r"[A-Za-z0-9_-]{16,64}", proof_nonce
+    ) is None:
+        raise ReleasePolicyError("watchdog write-authority nonce is invalid")
     proof_verified_at = _parse_time(
         str(write_authority.get("verified_at") or "")
     )
@@ -675,6 +694,22 @@ def _strict_external_receipts(
     cancel_proof = capabilities["cancel_workflow_run"]
     if not isinstance(reject_proof, dict) or not isinstance(cancel_proof, dict):
         raise ReleasePolicyError("watchdog write-authority capability proof is invalid")
+    if set(reject_proof) != {
+        "status",
+        "mode",
+        "nonce",
+        "run_id",
+        "run_url",
+        "observed_state",
+    } or set(cancel_proof) != {
+        "status",
+        "mode",
+        "nonce",
+        "run_id",
+        "run_url",
+        "observed_conclusion",
+    }:
+        raise ReleasePolicyError("watchdog write-authority capability proof is invalid")
     reject_run_id = reject_proof.get("run_id")
     cancel_run_id = cancel_proof.get("run_id")
     if any(
@@ -689,13 +724,34 @@ def _strict_external_receipts(
     )
     if (
         reject_proof.get("status") != "verified"
+        or reject_proof.get("mode") != "reject-pending-deployment"
+        or reject_proof.get("nonce") != proof_nonce
         or reject_proof.get("observed_state") != "rejected"
         or reject_proof.get("run_url") != f"{expected_run_url}{reject_run_id}"
         or cancel_proof.get("status") != "verified"
+        or cancel_proof.get("mode") != "cancel-workflow-run"
+        or cancel_proof.get("nonce") != proof_nonce
         or cancel_proof.get("observed_conclusion") != "cancelled"
         or cancel_proof.get("run_url") != f"{expected_run_url}{cancel_run_id}"
     ):
         raise ReleasePolicyError("watchdog write-authority readback is invalid")
+    worker_attestation = write_authority.get("worker_attestation")
+    if not isinstance(worker_attestation, dict) or set(worker_attestation) != {
+        "algorithm",
+        "worker_version_id",
+        "signature",
+    }:
+        raise ReleasePolicyError("watchdog write-authority attestation is invalid")
+    attestation_version = worker_attestation.get("worker_version_id")
+    attestation_signature = worker_attestation.get("signature")
+    if (
+        worker_attestation.get("algorithm") != "HMAC-SHA256"
+        or not isinstance(attestation_version, str)
+        or re.fullmatch(r"[A-Za-z0-9._-]{1,128}", attestation_version) is None
+        or not isinstance(attestation_signature, str)
+        or SHA256.fullmatch(attestation_signature) is None
+    ):
+        raise ReleasePolicyError("watchdog write-authority attestation is invalid")
     write_authority_sha256 = _sha_bytes(_canonical(write_authority))
     if watchdog.get("write_authority_sha256") != write_authority_sha256:
         raise ReleasePolicyError("watchdog write-authority digest does not match")

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -82,11 +82,14 @@ class ReleaseCandidateTests(unittest.TestCase):
             ],
             "environment": policy["github_environment"]["name"],
             "target_head_sha": self.RELEASE_SOURCE_SHA,
+            "nonce": "watchdog-20260830-a1b2c3d4",
             "verified_at": now.isoformat(),
             "verified_by": "github-user:emiliomartucci",
             "capabilities": {
                 "reject_pending_deployment": {
                     "status": "verified",
+                    "mode": "reject-pending-deployment",
+                    "nonce": "watchdog-20260830-a1b2c3d4",
                     "run_id": 1001,
                     "run_url": (
                         "https://github.com/emiliomartucci/marvis/actions/runs/1001"
@@ -95,12 +98,19 @@ class ReleaseCandidateTests(unittest.TestCase):
                 },
                 "cancel_workflow_run": {
                     "status": "verified",
+                    "mode": "cancel-workflow-run",
+                    "nonce": "watchdog-20260830-a1b2c3d4",
                     "run_id": 1002,
                     "run_url": (
                         "https://github.com/emiliomartucci/marvis/actions/runs/1002"
                     ),
                     "observed_conclusion": "cancelled",
                 },
+            },
+            "worker_attestation": {
+                "algorithm": "HMAC-SHA256",
+                "worker_version_id": "worker-canary-version-122",
+                "signature": "a" * 64,
             },
         }
         watchdog = {
@@ -694,6 +704,50 @@ class ReleaseCandidateTests(unittest.TestCase):
         cancel["run_id"] = 1001
         cancel["run_url"] = "https://github.com/emiliomartucci/marvis/actions/runs/1001"
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "run identity"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_write_authority_binds_modes_to_one_nonce(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        reject = watchdog["write_authority"]["capabilities"][
+            "reject_pending_deployment"
+        ]
+        reject["nonce"] = "watchdog-20260830-different"
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "readback"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog["write_authority"]["capabilities"]["cancel_workflow_run"][
+            "mode"
+        ] = "reject-pending-deployment"
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "readback"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_write_authority_requires_worker_attestation(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog["write_authority"]["worker_attestation"]["signature"] = "bad"
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "attestation"):
             candidate._strict_external_receipts(
                 policy,
                 release_source_sha=self.RELEASE_SOURCE_SHA,

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -73,6 +73,36 @@ class ReleaseCandidateTests(unittest.TestCase):
             "verified_by": "owner",
             "coordinates_sha256": candidate.publisher_coordinates_sha256(policy),
         }
+        write_authority = {
+            "schema": candidate.WATCHDOG_WRITE_AUTHORITY_SCHEMA,
+            "status": "verified",
+            "repository": policy["repository"],
+            "canary_workflow": policy["approval_watchdog"][
+                "write_authority_canary_workflow"
+            ],
+            "environment": policy["github_environment"]["name"],
+            "target_head_sha": self.RELEASE_SOURCE_SHA,
+            "verified_at": now.isoformat(),
+            "verified_by": "github-user:emiliomartucci",
+            "capabilities": {
+                "reject_pending_deployment": {
+                    "status": "verified",
+                    "run_id": 1001,
+                    "run_url": (
+                        "https://github.com/emiliomartucci/marvis/actions/runs/1001"
+                    ),
+                    "observed_state": "rejected",
+                },
+                "cancel_workflow_run": {
+                    "status": "verified",
+                    "run_id": 1002,
+                    "run_url": (
+                        "https://github.com/emiliomartucci/marvis/actions/runs/1002"
+                    ),
+                    "observed_conclusion": "cancelled",
+                },
+            },
+        }
         watchdog = {
             "schema": candidate.EXTERNAL_RECEIPT_SCHEMA,
             "kind": "approval_watchdog",
@@ -87,6 +117,9 @@ class ReleaseCandidateTests(unittest.TestCase):
             "workflow": policy["trusted_publisher"]["workflow"],
             "environment": policy["github_environment"]["name"],
             "candidate_tag": policy["candidate_tag"],
+            "write_authority_canary_workflow": policy["approval_watchdog"][
+                "write_authority_canary_workflow"
+            ],
             "approval_deadline_hours": policy["approval_deadline_hours"],
             "late_approval_upload_guard": True,
             "target_head_sha": self.RELEASE_SOURCE_SHA,
@@ -96,6 +129,10 @@ class ReleaseCandidateTests(unittest.TestCase):
                 "tag": "release-watchdog-041",
                 "timestamp": now.isoformat(),
             },
+            "write_authority": write_authority,
+            "write_authority_sha256": candidate._sha_bytes(
+                candidate._canonical(write_authority)
+            ),
         }
         return trusted, watchdog
 
@@ -543,6 +580,10 @@ class ReleaseCandidateTests(unittest.TestCase):
         self.assertEqual(
             set(summaries), {"trusted_publisher", "approval_watchdog"}
         )
+        self.assertEqual(
+            summaries["approval_watchdog"]["write_authority_sha256"],
+            watchdog["write_authority_sha256"],
+        )
 
     def test_watchdog_for_another_tag_is_rejected(self) -> None:
         now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
@@ -616,6 +657,102 @@ class ReleaseCandidateTests(unittest.TestCase):
                 trusted_publisher_receipt=trusted,
                 approval_watchdog_receipt=watchdog,
             )
+
+    def test_watchdog_requires_persisted_write_authority_proof(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog.pop("write_authority")
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "write-authority proof"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_write_authority_is_bound_to_the_release_source(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog["write_authority"]["target_head_sha"] = "b" * 40
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "coordinates"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_write_authority_requires_distinct_canary_runs(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        cancel = watchdog["write_authority"]["capabilities"]["cancel_workflow_run"]
+        cancel["run_id"] = 1001
+        cancel["run_url"] = "https://github.com/emiliomartucci/marvis/actions/runs/1001"
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "run identity"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_write_authority_proof_expires_after_24_hours(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog["write_authority"]["verified_at"] = (
+            now - timedelta(hours=25)
+        ).isoformat()
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "stale or unordered"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_watchdog_write_authority_digest_is_immutable(self) -> None:
+        now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+        policy = self.policy()
+        trusted, watchdog = self.external_receipts(now, policy)
+        watchdog["write_authority_sha256"] = "0" * 64
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "digest"):
+            candidate._strict_external_receipts(
+                policy,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                now=now,
+                trusted_publisher_receipt=trusted,
+                approval_watchdog_receipt=watchdog,
+            )
+
+    def test_write_authority_canary_workflow_is_bounded_and_non_publishing(self) -> None:
+        workflow_path = ROOT / ".github/workflows/watchdog-canary.yml"
+        workflow = yaml.load(workflow_path.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+        self.assertEqual(set(workflow["on"]), {"workflow_dispatch"})
+        self.assertEqual(workflow["permissions"], {"contents": "read"})
+        self.assertEqual(
+            set(workflow["jobs"]),
+            {"reject-pending-deployment", "cancel-workflow-run"},
+        )
+        self.assertEqual(
+            workflow["jobs"]["reject-pending-deployment"]["environment"], "pypi"
+        )
+        self.assertEqual(
+            workflow["jobs"]["reject-pending-deployment"]["timeout-minutes"], "1"
+        )
+        self.assertEqual(
+            workflow["jobs"]["cancel-workflow-run"]["timeout-minutes"], "2"
+        )
+        source = workflow_path.read_text(encoding="utf-8")
+        self.assertNotIn("uses:", source)
+        self.assertNotIn("publish", source.lower())
 
     def test_manifest_byte_tamper_is_rejected(self) -> None:
         with self.active_candidate_for_unit_test(), tempfile.TemporaryDirectory(


### PR DESCRIPTION
## Summary
- require a fresh owner-approved two-run canary before a watchdog receipt is accepted
- bind rejection and cancellation evidence to the exact repository, environment, reviewer, nonce, mode and release commit
- require the Cloud watchdog itself to sign the causal mutation proof
- add a bounded non-publishing canary workflow with one- and two-minute ceilings

## Verification
- Python release-contract suite: 65/65 green on committed HEAD
- final PR CI: python contract, desktop UI and immutable candidate all green
- independent P0/P1 review: green

Marvis task: ac2527d2-6e81-4093-8b89-e46154aba579
Cloud dependency: emiliomartucci/marvisx-cloud#49

This PR does not dispatch the canary, tag a release, publish to PyPI, deploy Cloud, or set secrets.