### PR TITLE
test(release): refresh OSS 0.4.1 CI foundation

### DIFF
--- a/contracts/ci/collection-v1.json
+++ b/contracts/ci/collection-v1.json
@@ -44,7 +44,7 @@
     {
       "path": "scripts",
       "pattern": "test_*.py",
-      "minimum_collected": 209,
+      "minimum_collected": 228,
       "allowed_skips": 0,
       "required_node_suffixes": [
         "CompatibilityContractTests.test_current_contract_passes",

--- a/scripts/test_verify_ci_collection.py
+++ b/scripts/test_verify_ci_collection.py
@@ -26,7 +26,7 @@ class CICollectionContractTests(unittest.TestCase):
         # 444 API + 32 CLI tests from a clean checkout. Keep this independent
         # from generated Console assets and other local build by-products.
         self.assertGreaterEqual(result["pytest_collected"], 476)
-        self.assertGreaterEqual(result["unittest_collected"], 209)
+        self.assertGreaterEqual(result["unittest_collected"], 228)
 
     def test_lowered_collection_floor_is_not_a_bypass(self) -> None:
         with tempfile.TemporaryDirectory(prefix="marvis-ci-contract-") as raw:


### PR DESCRIPTION
## Outcome

Refreshes the immutable release CI foundation on the exact product merge `285d65d43e53fb4b23bfca770ae79d4ad9056c98`. It raises the fail-closed governance collection floor from 209 to the verified current total of 228 tests.

This PR does not activate, tag or publish 0.4.1. Its exact merge SHA will become the foundation of a separate release-only PR.

## Verification

- CI collection readback: 444 API + 32 CLI + 228 unittest tests
- 11 collection-contract tests passed locally
- changed paths are limited to the collection contract and its test

Marvis task: `3d424629-af9c-43e5-9810-c78688f0727c`.