### PR TITLE
release(oss): activate immutable 0.4.1 candidate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT: ${{ vars.MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT }}
-      MARVIS_APPROVAL_WATCHDOG_RECEIPT: ${{ vars.MARVIS_APPROVAL_WATCHDOG_RECEIPT }}
+      MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT: ${{ github.event_name != 'pull_request' && vars.MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT || '' }}
+      MARVIS_APPROVAL_WATCHDOG_RECEIPT: ${{ github.event_name != 'pull_request' && vars.MARVIS_APPROVAL_WATCHDOG_RECEIPT || '' }}
     steps:
       - name: Check out the reviewed source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ No changes yet.
 ## [0.4.1] - candidate
 
 Security and provenance refresh based on the exact merged Plan B product base
-and the separately pinned CI evidence foundation from PR #56. The release
+and the separately pinned CI evidence foundation from PR #61. The release
 keeps the local CLI, MCP, hooks and packaged GUI contracts while updating the
 shared engine and its regression coverage.
 

--- a/contracts/ci/collection-v1.json
+++ b/contracts/ci/collection-v1.json
@@ -53,7 +53,7 @@
         "LocalUpgradeTests.test_synthetic_prior_upgrade_and_rollback",
         "LocalUpgradeTests.test_cli_upgrade_uses_settings_projects_root_without_environment",
         "LocalUpgradeTests.test_runtime_settings_preserve_explicit_projects_root",
-        "ReleaseCandidateTests.test_real_release_candidate_is_invalidated_by_the_source_advance",
+        "ReleaseCandidateTests.test_real_release_candidate_static_policy",
         "ReleaseCandidateTests.test_invalidated_pull_request_skips_every_expensive_release_step"
       ]
     }

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -3,18 +3,15 @@
   "package": "marvisx-cli",
   "repository": "emiliomartucci/marvis",
   "release_branch": "main",
-  "plan_b_product_base_sha": "1e8f3977bd1085e358c34e4b08bdcca058130757",
+  "plan_b_product_base_sha": "285d65d43e53fb4b23bfca770ae79d4ad9056c98",
   "release_foundation": {
     "repository": "emiliomartucci/marvis",
-    "pull_request": 56,
-    "candidate_sha": "110317349c3f650cd3043b82080bfe991edcf0ee",
-    "merge_sha": "bab84da1a4c104b6ab273dc5166752c97dac5a1b",
+    "pull_request": 61,
+    "candidate_sha": "ce7d6238c789f006284868e209a0712da64c3245",
+    "merge_sha": "bb66446521ec615ca8598140173ee9d2b3fa7b8e",
     "expected_changed_paths": [
-      ".github/workflows/ci.yml",
       "contracts/ci/collection-v1.json",
-      "scripts/test_release_candidate.py",
-      "scripts/test_verify_ci_collection.py",
-      "scripts/verify_ci_collection.py"
+      "scripts/test_verify_ci_collection.py"
     ]
   },
   "shared_source": {
@@ -25,10 +22,7 @@
     "engine_pin": "contracts/engine-pin.yaml"
   },
   "candidate_state": {
-    "status": "invalidated",
-    "reason": "shared_source_advanced_after_release_foundation",
-    "invalidated_by_shared_source_sha": "ab1fa58eae705a25ca46ea6829eb0d538794ee52",
-    "required_next_gate": "merge_product_projection_then_refresh_release_foundation"
+    "status": "active"
   },
   "candidate_version": "0.4.1",
   "candidate_tag": "v0.4.1",

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -4,18 +4,18 @@ This release projects the verified public/shared Marvis engine refresh into the
 local single-user product while preserving its CLI, MCP, hooks, local GUI and
 package contracts.
 
-The current shared source is MarvisX PR `#316`: reviewed candidate
-`4efd50cbe6b70c0febdd6b9ea0b812aa7d71569d`, merged as
-`64e96cb7e90292816296750906db68ec81c4a37e`. The release policy binds these
+The current shared source is MarvisX PR `#348`: reviewed candidate
+`471f88f21dc0880c903ec6401621a52d2a801b0d`, merged as
+`ab1fa58eae705a25ca46ea6829eb0d538794ee52`. The release policy binds these
 coordinates to the local engine pin and verifies the GitHub readback before
 publication can proceed.
 
-The exact Plan B product projection is Marvis PR `#55`: final candidate
-`39d7299ae26824639e8004e6dc29c3accc72775c`, merged as
-`1e8f3977bd1085e358c34e4b08bdcca058130757`. The separate CI evidence
-foundation is Marvis PR `#56`: final candidate
-`110317349c3f650cd3043b82080bfe991edcf0ee`, merged as
-`bab84da1a4c104b6ab273dc5166752c97dac5a1b`. Only the release-specific delta
+The exact Plan B product projection is Marvis PR `#60`: final candidate
+`7f088d76ec5fc588dc98e990434db77c7a3c8c05`, merged as
+`285d65d43e53fb4b23bfca770ae79d4ad9056c98`. The separate CI evidence
+foundation is Marvis PR `#61`: final candidate
+`ce7d6238c789f006284868e209a0712da64c3245`, merged as
+`bb66446521ec615ca8598140173ee9d2b3fa7b8e`. Only the release-specific delta
 after that foundation is admitted by the unchanged release allowlist.
 
 Highlights:

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -160,17 +160,37 @@ class ReleaseCandidateTests(unittest.TestCase):
         }
         return trusted, watchdog
 
-    def test_real_release_candidate_is_invalidated_by_the_source_advance(self) -> None:
-        policy = self.policy()
-        shared_source = candidate._shared_source_coordinates(ROOT, policy)
-        state = candidate._candidate_state(policy, shared_source=shared_source)
-        self.assertEqual(state["status"], "invalidated")
+    def test_real_release_candidate_static_policy(self) -> None:
+        report = candidate.validate_static(ROOT)
+        self.assertEqual(report["status"], "static_green_external_gates_open")
+        self.assertEqual(report["version"], "0.4.1")
+        self.assertEqual(report["release_branch"], "main")
         self.assertEqual(
-            state["invalidated_by_shared_source_sha"],
+            report["product_base_sha"],
+            "285d65d43e53fb4b23bfca770ae79d4ad9056c98",
+        )
+        self.assertEqual(
+            report["release_foundation"]["candidate_sha"],
+            "ce7d6238c789f006284868e209a0712da64c3245",
+        )
+        self.assertEqual(
+            report["release_foundation"]["merge_sha"],
+            "bb66446521ec615ca8598140173ee9d2b3fa7b8e",
+        )
+        self.assertEqual(
+            report["release_foundation"]["changed_paths"],
+            self.policy()["release_foundation"]["expected_changed_paths"],
+        )
+        self.assertEqual(
+            report["shared_source"]["candidate_sha"],
+            "471f88f21dc0880c903ec6401621a52d2a801b0d",
+        )
+        self.assertEqual(
+            report["shared_source"]["merge_sha"],
             "ab1fa58eae705a25ca46ea6829eb0d538794ee52",
         )
-        with self.assertRaisesRegex(candidate.ReleasePolicyError, "invalidated"):
-            candidate.validate_static(ROOT)
+        self.assertEqual(len(report["action_pins"]), 5)
+        self.assertEqual(candidate.candidate_state_report(ROOT)["status"], "active")
 
     def test_candidate_invalidation_cannot_name_an_unrelated_source(self) -> None:
         policy = self.policy()
@@ -188,7 +208,7 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_active_candidate_cannot_keep_stale_invalidation_evidence(self) -> None:
         policy = self.policy()
-        policy["candidate_state"]["status"] = "active"
+        policy["candidate_state"]["reason"] = "stale"
         shared_source = candidate._shared_source_coordinates(ROOT, policy)
         with self.assertRaisesRegex(
             candidate.ReleasePolicyError, "active candidate state contains stale evidence"
@@ -239,6 +259,12 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_invalidated_pull_request_skips_every_expensive_release_step(self) -> None:
         workflow = yaml.safe_load((ROOT / candidate.WORKFLOW_PATH).read_text())
+        build_env = workflow["jobs"]["build"]["env"]
+        for variable in (
+            candidate._TRUSTED_PUBLISHER_RECEIPT_ENV,
+            candidate._APPROVAL_WATCHDOG_RECEIPT_ENV,
+        ):
+            self.assertIn("github.event_name != 'pull_request'", build_env[variable])
         steps = workflow["jobs"]["build"]["steps"]
         protected = {
             "Run the live pre-tag preflight before the expensive build",
@@ -314,7 +340,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         expected = policy["release_foundation"]
         pull = {
             "state": "closed",
-            "merged_at": "2026-08-29T15:01:11Z",
+            "merged_at": "2026-08-31T12:47:21Z",
             "head": {"sha": expected["candidate_sha"]},
             "merge_commit_sha": expected["merge_sha"],
         }
@@ -322,7 +348,7 @@ class ReleaseCandidateTests(unittest.TestCase):
             report = candidate._release_foundation_readback(
                 ROOT, policy, token="masked", api_url="https://api.example"
             )
-        self.assertEqual(report["pull_request"], 56)
+        self.assertEqual(report["pull_request"], 61)
         self.assertEqual(
             report["changed_paths"], expected["expected_changed_paths"]
         )


### PR DESCRIPTION
Activates the immutable OSS 0.4.1 candidate after exact product merge 285d65d43e53fb4b23bfca770ae79d4ad9056c98 and exact CI foundation merge bb66446521ec615ca8598140173ee9d2b3fa7b8e. Refreshes provenance, keeps the release delta allowlisted, and prevents pull-request validation from consuming live external PyPI receipts bound to another SHA. Local evidence: 65 release tests, 11 collection-contract tests, static preflight, and CI collection 476 pytest plus 228 unittest. No tag, PyPI publication, deploy, or release workflow dispatch is performed by this PR. Marvis task: 3d424629-af9c-43e5-9810-c78688f0727c.