### PR TITLE
fix(release): verify private source via owner receipt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
     env:
       MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT: ${{ github.event_name != 'pull_request' && vars.MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT || '' }}
       MARVIS_APPROVAL_WATCHDOG_RECEIPT: ${{ github.event_name != 'pull_request' && vars.MARVIS_APPROVAL_WATCHDOG_RECEIPT || '' }}
+      MARVIS_SHARED_SOURCE_OWNER_RECEIPT: ${{ github.event_name != 'pull_request' && vars.MARVIS_SHARED_SOURCE_OWNER_RECEIPT || '' }}
     steps:
       - name: Check out the reviewed source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -253,6 +254,7 @@ jobs:
     env:
       MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT: ${{ vars.MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT }}
       MARVIS_APPROVAL_WATCHDOG_RECEIPT: ${{ vars.MARVIS_APPROVAL_WATCHDOG_RECEIPT }}
+      MARVIS_SHARED_SOURCE_OWNER_RECEIPT: ${{ vars.MARVIS_SHARED_SOURCE_OWNER_RECEIPT }}
     steps:
       - name: Check out the tagged source read-only
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
@@ -397,6 +399,7 @@ jobs:
     env:
       MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT: ${{ vars.MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT }}
       MARVIS_APPROVAL_WATCHDOG_RECEIPT: ${{ vars.MARVIS_APPROVAL_WATCHDOG_RECEIPT }}
+      MARVIS_SHARED_SOURCE_OWNER_RECEIPT: ${{ vars.MARVIS_SHARED_SOURCE_OWNER_RECEIPT }}
     steps:
       - name: Check out the tagged source
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -67,6 +67,7 @@
   "external_receipts": {
     "trusted_publisher_variable": "MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT",
     "approval_watchdog_variable": "MARVIS_APPROVAL_WATCHDOG_RECEIPT",
+    "shared_source_variable": "MARVIS_SHARED_SOURCE_OWNER_RECEIPT",
     "schema": "marvis-external-release-receipt/v1"
   },
   "build": {

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -38,12 +38,15 @@ now satisfied; owner approval and immutable publication gates remain open.
 After this restricted release-source PR merges, the explicit `workflow_dispatch`
 preflight must pass at the exact remote `main` head before a tag is created. It
 fails before the expensive build if the version exists, the protected
-environment drifts, or either external owner receipt is absent or stale.
+environment drifts, or any external owner receipt is absent or stale.
 Those receipts are supplied outside the candidate through the repository
-Actions variables `MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT` and
-`MARVIS_APPROVAL_WATCHDOG_RECEIPT`; the policy stores only their expected
-schema and coordinates. A successful, fresh `workflow_dispatch` run for the
-same SHA is embedded in the immutable manifest before a tag build can publish.
+Actions variables `MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT`,
+`MARVIS_APPROVAL_WATCHDOG_RECEIPT` and
+`MARVIS_SHARED_SOURCE_OWNER_RECEIPT`; the policy stores only their expected
+schema and coordinates. The third variable carries a fresh, non-secret owner
+readback because a public repository token cannot read the private MarvisX
+repository. A successful, fresh `workflow_dispatch` run for the same SHA is
+embedded in the immutable manifest before a tag build can publish.
 
 The dated namespace and failed-release evidence is recorded in
 [`2026-08-28-public-release-preflight.md`](2026-08-28-public-release-preflight.md).

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -2,8 +2,9 @@
 """Fail-closed public release policy, artifact manifest and registry readback.
 
 The PR path validates and builds but cannot publish. A tag path must additionally
-pass live GitHub-environment checks, a fresh owner readback of the PyPI trusted
-publisher, and an external 24-hour approval-watchdog receipt before upload.
+pass live GitHub-environment checks, a fresh owner readback of the private shared
+source and PyPI trusted publisher, and an external 24-hour approval-watchdog
+receipt before upload.
 """
 from __future__ import annotations
 
@@ -61,6 +62,7 @@ GENERATED_TRACKED_DELETIONS = frozenset({"core/api/console_dist/.gitkeep"})
 _FILE_CHUNK_BYTES = 1024 * 1024
 _TRUSTED_PUBLISHER_RECEIPT_ENV = "MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT"
 _APPROVAL_WATCHDOG_RECEIPT_ENV = "MARVIS_APPROVAL_WATCHDOG_RECEIPT"
+_SHARED_SOURCE_RECEIPT_ENV = "MARVIS_SHARED_SOURCE_OWNER_RECEIPT"
 
 
 class ReleasePolicyError(RuntimeError):
@@ -399,23 +401,57 @@ def _shared_source_readback(
     *,
     token: str,
     api_url: str,
+    now: datetime | None = None,
+    receipt_raw: str | None = None,
 ) -> dict[str, Any]:
+    del token, api_url
     expected = _shared_source_coordinates(root, policy)
-    pull = _request_json(
-        f"{api_url}/repos/{expected['repository']}/pulls/{expected['pull_request']}",
-        token=token,
+    receipt = _external_receipt(
+        receipt_raw
+        if receipt_raw is not None
+        else os.environ.get(_SHARED_SOURCE_RECEIPT_ENV),
+        kind="shared_source_owner_readback",
+    )
+    expected_coordinates = {
+        key: expected[key]
+        for key in (
+            "repository",
+            "pull_request",
+            "candidate_sha",
+            "merge_sha",
+            "engine_pin",
+            "engine_pin_sha256",
+        )
+    }
+    expected_coordinates_sha256 = _sha_bytes(_canonical(expected_coordinates))
+    observed_coordinates = {key: receipt.get(key) for key in expected_coordinates}
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    verified_at = _parse_time(str(receipt.get("verified_at") or ""))
+    merged_at = _parse_time(str(receipt.get("merged_at") or ""))
+    age = (current - verified_at).total_seconds()
+    expected_verifier = (
+        f"github-user:{policy['github_environment']['required_reviewer_login']}"
     )
     if (
-        pull.get("state") != "closed"
-        or not pull.get("merged_at")
-        or (pull.get("head") or {}).get("sha") != expected["candidate_sha"]
-        or pull.get("merge_commit_sha") != expected["merge_sha"]
+        receipt.get("status") != "verified"
+        or receipt.get("state") != "closed"
+        or observed_coordinates != expected_coordinates
+        or receipt.get("coordinates_sha256") != expected_coordinates_sha256
+        or receipt.get("verified_by") != expected_verifier
+        or age < 0
+        or age > 24 * 3600
+        or merged_at > verified_at
     ):
-        raise ReleasePolicyError("shared-source PR identity differs from release policy")
+        raise ReleasePolicyError(
+            "shared-source owner readback is stale or differs from release policy"
+        )
     return {
         **expected,
-        "state": pull.get("state"),
-        "merged_at": pull.get("merged_at"),
+        "state": receipt["state"],
+        "merged_at": receipt["merged_at"],
+        "verified_at": receipt["verified_at"],
+        "verified_by": receipt["verified_by"],
+        "receipt_sha256": _sha_bytes(_canonical(receipt)),
     }
 
 
@@ -856,6 +892,8 @@ def validate_static(
         != _TRUSTED_PUBLISHER_RECEIPT_ENV
         or receipt_policy.get("approval_watchdog_variable")
         != _APPROVAL_WATCHDOG_RECEIPT_ENV
+        or receipt_policy.get("shared_source_variable")
+        != _SHARED_SOURCE_RECEIPT_ENV
     ):
         raise ReleasePolicyError("external receipt provider contract is invalid")
     resolved_head = str(_git(root, "rev-parse", head))
@@ -938,6 +976,7 @@ def validate_static(
         "installed-upgrade",
         "MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT",
         "MARVIS_APPROVAL_WATCHDOG_RECEIPT",
+        "MARVIS_SHARED_SOURCE_OWNER_RECEIPT",
         "environment: pypi",
         "pypa/gh-action-pypi-publish@" + expected_pins.get("pypa/gh-action-pypi-publish", ""),
     )
@@ -970,6 +1009,7 @@ def validate_static(
         'assert mcp["tool_count"] > 0',
         "MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT: ${{ vars.MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT }}",
         "MARVIS_APPROVAL_WATCHDOG_RECEIPT: ${{ vars.MARVIS_APPROVAL_WATCHDOG_RECEIPT }}",
+        "MARVIS_SHARED_SOURCE_OWNER_RECEIPT: ${{ vars.MARVIS_SHARED_SOURCE_OWNER_RECEIPT }}",
         "if: ${{ always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && (needs.build.result != 'success' || needs.release-record.result != 'success' || needs.prepublish.result != 'success' || needs.pypi.result != 'success' || needs.accept.result != 'success' || needs.finalize.result != 'success') }}",
         'echo "::error::Refusing to mutate an already-final GitHub Release."',
         'echo "::error::The failed candidate exists on PyPI; owner verification and yank are required."',
@@ -1020,6 +1060,8 @@ def validate_static(
         external_blockers.append("trusted_publisher_owner_readback")
     if not os.environ.get(_APPROVAL_WATCHDOG_RECEIPT_ENV):
         external_blockers.append("external_approval_watchdog")
+    if not os.environ.get(_SHARED_SOURCE_RECEIPT_ENV):
+        external_blockers.append("shared_source_owner_readback")
     return {
         "schema": "marvis-public-release-static-preflight/v1",
         "product_base_sha": base,

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -36,6 +36,7 @@ class ReleaseCandidateTests(unittest.TestCase):
             {
                 candidate._TRUSTED_PUBLISHER_RECEIPT_ENV: "",
                 candidate._APPROVAL_WATCHDOG_RECEIPT_ENV: "",
+                candidate._SHARED_SOURCE_RECEIPT_ENV: "",
             },
         )
         receipt_env.start()
@@ -160,6 +161,36 @@ class ReleaseCandidateTests(unittest.TestCase):
         }
         return trusted, watchdog
 
+    def shared_source_receipt(
+        self, now: datetime, policy: dict | None = None
+    ) -> dict:
+        policy = policy or self.policy()
+        expected = candidate._shared_source_coordinates(ROOT, policy)
+        coordinates = {
+            key: expected[key]
+            for key in (
+                "repository",
+                "pull_request",
+                "candidate_sha",
+                "merge_sha",
+                "engine_pin",
+                "engine_pin_sha256",
+            )
+        }
+        return {
+            "schema": candidate.EXTERNAL_RECEIPT_SCHEMA,
+            "kind": "shared_source_owner_readback",
+            "status": "verified",
+            **coordinates,
+            "coordinates_sha256": candidate._sha_bytes(
+                candidate._canonical(coordinates)
+            ),
+            "state": "closed",
+            "merged_at": "2026-08-31T11:50:49Z",
+            "verified_at": now.isoformat(),
+            "verified_by": "github-user:emiliomartucci",
+        }
+
     def test_real_release_candidate_static_policy(self) -> None:
         report = candidate.validate_static(ROOT)
         self.assertEqual(report["status"], "static_green_external_gates_open")
@@ -263,6 +294,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         for variable in (
             candidate._TRUSTED_PUBLISHER_RECEIPT_ENV,
             candidate._APPROVAL_WATCHDOG_RECEIPT_ENV,
+            candidate._SHARED_SOURCE_RECEIPT_ENV,
         ):
             self.assertIn("github.event_name != 'pull_request'", build_env[variable])
         steps = workflow["jobs"]["build"]["steps"]
@@ -314,25 +346,43 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_shared_source_readback_requires_exact_pr_candidate_and_merge(self) -> None:
         policy = self.policy()
         expected = policy["shared_source"]
-        pull = {
-            "state": "closed",
-            "merged_at": "2026-08-28T10:00:00Z",
-            "head": {"sha": expected["candidate_sha"]},
-            "merge_commit_sha": expected["merge_sha"],
-        }
-        with mock.patch.object(candidate, "_request_json", return_value=pull):
-            report = candidate._shared_source_readback(
-                ROOT, policy, token="masked", api_url="https://api.example"
-            )
+        now = datetime(2026, 8, 31, 12, 0, tzinfo=timezone.utc)
+        receipt = self.shared_source_receipt(now, policy)
+        report = candidate._shared_source_readback(
+            ROOT,
+            policy,
+            token="repository-scoped",
+            api_url="https://api.example",
+            now=now,
+            receipt_raw=json.dumps(receipt),
+        )
         self.assertEqual(report["candidate_sha"], expected["candidate_sha"])
         self.assertEqual(report["merge_sha"], expected["merge_sha"])
+        self.assertEqual(report["verified_by"], "github-user:emiliomartucci")
 
-        pull["head"]["sha"] = "a" * 40
-        with mock.patch.object(
-            candidate, "_request_json", return_value=pull
-        ), self.assertRaisesRegex(candidate.ReleasePolicyError, "identity"):
+        receipt["candidate_sha"] = "a" * 40
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "differs"):
             candidate._shared_source_readback(
-                ROOT, policy, token="masked", api_url="https://api.example"
+                ROOT,
+                policy,
+                token="repository-scoped",
+                api_url="https://api.example",
+                now=now,
+                receipt_raw=json.dumps(receipt),
+            )
+
+    def test_shared_source_owner_readback_expires_after_24_hours(self) -> None:
+        policy = self.policy()
+        verified = datetime(2026, 8, 30, 10, 0, tzinfo=timezone.utc)
+        receipt = self.shared_source_receipt(verified, policy)
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "stale"):
+            candidate._shared_source_readback(
+                ROOT,
+                policy,
+                token="repository-scoped",
+                api_url="https://api.example",
+                now=verified + timedelta(hours=25),
+                receipt_raw=json.dumps(receipt),
             )
 
     def test_release_foundation_is_exact_and_remotely_read_back(self) -> None:


### PR DESCRIPTION
Marvis task: 3d424629-af9c-43e5-9810-c78688f0727c

The exact OSS dispatch preflight proved that a repository-scoped GitHub token cannot read the private MarvisX sibling repository. This keeps the release fail-closed without adding a long-lived cross-repository token: a fresh, non-secret owner receipt is bound to the exact repository, PR, candidate SHA, merge SHA and engine-pin digest.

Local verification:
- release candidate tests: 66/66
- surface, local perimeter, desktop host and public-claims validators: passed
- no tag, GitHub Release or PyPI publication