### PR TITLE
fix(release): recover immutable OSS 0.4.2 publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -575,17 +575,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          release_state="$(gh api \
+          if release_json="$(gh api \
             "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
-            --jq '[.draft, .prerelease] | @tsv' 2>/dev/null || true)"
-          if [[ -z "$release_state" ]]; then
-            gh release create "$GITHUB_REF_NAME" \
-              --verify-tag \
-              --draft \
-              --prerelease \
-              --title "$GITHUB_REF_NAME [FAILED - DO NOT INSTALL]" \
-              --notes "The tagged release failed before acceptance. The tag and version are burned; use a new version after remediation."
-          else
+            2>/dev/null)"; then
+            release_state="$(jq -r '[.draft, .prerelease] | @tsv' <<< "$release_json")"
             IFS=$'\t' read -r draft prerelease <<< "$release_state"
             if [[ "$draft" == "true" ]]; then
               gh release edit "$GITHUB_REF_NAME" \
@@ -600,6 +593,13 @@ jobs:
               echo "::error::Refusing to mutate an already-final GitHub Release."
               exit 1
             fi
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --draft \
+              --prerelease \
+              --title "$GITHUB_REF_NAME [FAILED - DO NOT INSTALL]" \
+              --notes "The tagged release failed before acceptance. The tag and version are burned; use a new version after remediation."
           fi
 
           version="${GITHUB_REF_NAME#v}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses strict Semantic Versioning: `MAJOR.MINOR.PATCH`.
 
 No changes yet.
 
-## [0.4.1] - candidate
+## [0.4.2] - candidate
 
 Security and provenance refresh based on the exact merged Plan B product base
 and the separately pinned CI evidence foundation from PR #61. The release
@@ -26,9 +26,22 @@ shared engine and its regression coverage.
   database migrations and temporary compatibility tombstones remain.
 - Expanded Python 3.10-3.13, Linux, macOS and Windows install and upgrade proof.
 
-This section describes a release candidate only. Version 0.4.1 is not
+### Fixed
+
+- Isolated release unit tests from live GitHub tag variables so a tag run does
+  not accidentally enter publication mode.
+- Made failed GitHub Release lookups branch on the API exit status instead of
+  treating an error payload as an existing final release.
+
+This section describes a release candidate only. Version 0.4.2 is not
 published until the separate tag, PyPI and post-publication acceptance gates
 all succeed.
+
+## [0.4.1] - 2026-08-31 (failed, not published)
+
+The immutable tag exists, but the tag workflow stopped before the expensive
+build because unit tests inherited the live tag context. No GitHub Release or
+PyPI file was created. Version 0.4.1 is burned and must never be reused.
 
 ## [0.4.0] - 2026-06-19 (tentativo fallito, non pubblicato)
 

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -24,9 +24,9 @@
   "candidate_state": {
     "status": "active"
   },
-  "candidate_version": "0.4.1",
-  "candidate_tag": "v0.4.1",
-  "historical_failed_version": "0.4.0",
+  "candidate_version": "0.4.2",
+  "candidate_tag": "v0.4.2",
+  "historical_failed_version": "0.4.1",
   "approval_deadline_hours": 24,
   "allowed_release_delta": [
     ".github/workflows/release.yml",
@@ -59,7 +59,7 @@
     "repository": "emiliomartucci/marvis",
     "workflow": "release.yml",
     "environment": "pypi",
-    "candidate_tag": "v0.4.1",
+    "candidate_tag": "v0.4.2",
     "write_authority_canary_workflow": "watchdog-canary.yml",
     "approval_deadline_hours": 24,
     "late_approval_upload_guard": true

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -1,5 +1,10 @@
 # marvisx-cli 0.4.1
 
+> Historical failed attempt. The immutable `v0.4.1` tag exists, but its tag
+> workflow stopped before the package build. No GitHub Release or PyPI file was
+> created. This version is burned and must not be reused; the recovery release
+> is `0.4.2`.
+
 This release projects the verified public/shared Marvis engine refresh into the
 local single-user product while preserving its CLI, MCP, hooks, local GUI and
 package contracts.
@@ -32,21 +37,10 @@ Highlights:
 License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
-Publication status: active source candidate, not a published release. No tag,
-GitHub Release or PyPI file exists. The exact product and foundation pins are
-now satisfied; owner approval and immutable publication gates remain open.
-After this restricted release-source PR merges, the explicit `workflow_dispatch`
-preflight must pass at the exact remote `main` head before a tag is created. It
-fails before the expensive build if the version exists, the protected
-environment drifts, or any external owner receipt is absent or stale.
-Those receipts are supplied outside the candidate through the repository
-Actions variables `MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT`,
-`MARVIS_APPROVAL_WATCHDOG_RECEIPT` and
-`MARVIS_SHARED_SOURCE_OWNER_RECEIPT`; the policy stores only their expected
-schema and coordinates. The third variable carries a fresh, non-secret owner
-readback because a public repository token cannot read the private MarvisX
-repository. A successful, fresh `workflow_dispatch` run for the same SHA is
-embedded in the immutable manifest before a tag build can publish.
+Publication status: failed historical attempt, not a published release. The
+annotated tag exists and remains immutable. The tag workflow stopped before the
+package build because unit tests inherited the live GitHub tag context. No
+GitHub Release or PyPI file was created. Recovery continues only as `0.4.2`.
 
 The dated namespace and failed-release evidence is recorded in
 [`2026-08-28-public-release-preflight.md`](2026-08-28-public-release-preflight.md).

--- a/docs/releases/0.4.2.md
+++ b/docs/releases/0.4.2.md
@@ -1,0 +1,35 @@
+# marvisx-cli 0.4.2
+
+This recovery release projects the verified public/shared Marvis engine refresh
+into the local single-user product while preserving its CLI, MCP, hooks, local
+GUI and package contracts.
+
+The shared source remains MarvisX PR `#348`: reviewed candidate
+`471f88f21dc0880c903ec6401621a52d2a801b0d`, merged as
+`ab1fa58eae705a25ca46ea6829eb0d538794ee52`. The Plan B product projection is
+Marvis PR `#60`, merged as
+`285d65d43e53fb4b23bfca770ae79d4ad9056c98`; the CI evidence foundation is PR
+`#61`, merged as `bb66446521ec615ca8598140173ee9d2b3fa7b8e`.
+
+Highlights:
+
+- hardened identity, authorization, throttling and audit boundaries;
+- deterministic provenance back to the exact shared MarvisX source;
+- Python 3.10-3.13 and Linux, macOS and Windows install coverage;
+- upgrade, rollback and exact PyPI artifact acceptance checks;
+- removal of retired Heypocket, n8n and Reddit runtime integrations while
+  retaining historical database migrations and compatibility tombstones.
+
+Version `0.4.1` is a burned, unpublished historical attempt: its immutable tag
+exists, but the workflow stopped before the package build and no GitHub Release
+or PyPI file was created. Version `0.4.2` additionally isolates unit tests from
+live tag variables and makes failed GitHub Release lookups fail closed without
+mistaking an API error payload for an existing final release.
+
+License: Business Source License 1.1. This is source-available open-core
+software and all public descriptions remain bounded by the current BSL terms.
+
+Publication status: active recovery candidate, not yet published. Publication
+requires a successful explicit preflight at the exact merged `main` commit,
+fresh owner receipts, one immutable `v0.4.2` tag build, exact PyPI readback and
+post-publication installation, upgrade and rollback acceptance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marvisx-cli"
-version = "0.4.1"
+version = "0.4.2"
 description = "MarvisX open-core — agent-native company-brain CLI runtime (init, status, brief, triage)"
 # long_description is sourced from this README (rendered on PyPI). BSL-1.1 is
 # source-available; `license` carries the SPDX-style text marker.

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -37,6 +37,9 @@ class ReleaseCandidateTests(unittest.TestCase):
                 candidate._TRUSTED_PUBLISHER_RECEIPT_ENV: "",
                 candidate._APPROVAL_WATCHDOG_RECEIPT_ENV: "",
                 candidate._SHARED_SOURCE_RECEIPT_ENV: "",
+                "GITHUB_EVENT_NAME": "",
+                "GITHUB_REF": "",
+                "GITHUB_REF_NAME": "",
             },
         )
         receipt_env.start()
@@ -61,13 +64,13 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def write_release_artifacts(self, dist: Path) -> tuple[Path, Path]:
         dist.mkdir(parents=True, exist_ok=True)
-        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.1\n\n"
-        wheel = dist / "marvisx_cli-0.4.1-py3-none-any.whl"
+        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.2\n\n"
+        wheel = dist / "marvisx_cli-0.4.2-py3-none-any.whl"
         with zipfile.ZipFile(wheel, "w") as archive:
-            archive.writestr("marvisx_cli-0.4.1.dist-info/METADATA", metadata)
-        sdist = dist / "marvisx_cli-0.4.1.tar.gz"
+            archive.writestr("marvisx_cli-0.4.2.dist-info/METADATA", metadata)
+        sdist = dist / "marvisx_cli-0.4.2.tar.gz"
         with tarfile.open(sdist, "w:gz") as archive:
-            info = tarfile.TarInfo("marvisx_cli-0.4.1/PKG-INFO")
+            info = tarfile.TarInfo("marvisx_cli-0.4.2/PKG-INFO")
             info.size = len(metadata)
             archive.addfile(info, io.BytesIO(metadata))
         return wheel, sdist
@@ -194,7 +197,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_real_release_candidate_static_policy(self) -> None:
         report = candidate.validate_static(ROOT)
         self.assertEqual(report["status"], "static_green_external_gates_open")
-        self.assertEqual(report["version"], "0.4.1")
+        self.assertEqual(report["version"], "0.4.2")
         self.assertEqual(report["release_branch"], "main")
         self.assertEqual(
             report["product_base_sha"],
@@ -260,7 +263,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         scenarios = {
             ("pull_request", "refs/pull/1/merge"): set(),
             ("workflow_dispatch", "refs/heads/main"): set(),
-            ("push", "refs/tags/v0.4.1"): {
+            ("push", "refs/tags/v0.4.2"): {
                 "release-record",
                 "prepublish",
                 "pypi",
@@ -281,12 +284,19 @@ class ReleaseCandidateTests(unittest.TestCase):
             enabled = mutating if event == "push" and ref.startswith("refs/tags/v") else set()
             self.assertEqual(enabled, expected_jobs)
         blocks = candidate._workflow_job_blocks(workflow)
+        contain_block = blocks["contain"]
+        self.assertIn('if release_json="$(gh api', contain_block)
+        self.assertNotIn("2>/dev/null || true", contain_block)
         for job in ("release-record", "pypi", "finalize"):
             self.assertNotIn("actions/checkout@", blocks[job])
             self.assertNotIn("scripts/", blocks[job])
             self.assertNotIn("pip install", blocks[job])
         self.assertIn("contents: read", blocks["accept"])
         self.assertNotIn("contents: write", blocks["accept"])
+
+    def test_unit_suite_clears_live_tag_context(self) -> None:
+        for variable in ("GITHUB_EVENT_NAME", "GITHUB_REF", "GITHUB_REF_NAME"):
+            self.assertEqual(candidate.os.environ.get(variable), "")
 
     def test_invalidated_pull_request_skips_every_expensive_release_step(self) -> None:
         workflow = yaml.safe_load((ROOT / candidate.WORKFLOW_PATH).read_text())
@@ -533,7 +543,7 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_tag_build_rejects_another_trigger_tag(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "another-tag"):
-            candidate._validate_tag_trigger("v0.4.1", "refs/tags/another-tag")
+            candidate._validate_tag_trigger("v0.4.2", "refs/tags/another-tag")
 
     def test_release_delta_rejects_product_code(self) -> None:
         foundation = candidate._release_foundation_coordinates(ROOT, self.policy())
@@ -669,7 +679,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
         policy = self.policy()
         trusted, watchdog = self.external_receipts(now, policy)
-        watchdog["candidate_tag"] = "v0.4.2"
+        watchdog["candidate_tag"] = "v0.4.3"
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "coordinates"):
             candidate._strict_external_receipts(
                 policy,
@@ -943,20 +953,20 @@ class ReleaseCandidateTests(unittest.TestCase):
                 candidate.build_manifest(ROOT, dist, source_sha=base)
 
     def test_sdist_uses_root_metadata_and_ignores_egg_info_copy(self) -> None:
-        metadata = b"Name: marvisx-cli\nVersion: 0.4.1\n\n"
+        metadata = b"Name: marvisx-cli\nVersion: 0.4.2\n\n"
         with tempfile.TemporaryDirectory(prefix="release-sdist-") as raw:
-            archive_path = Path(raw) / "marvisx_cli-0.4.1.tar.gz"
+            archive_path = Path(raw) / "marvisx_cli-0.4.2.tar.gz"
             with tarfile.open(archive_path, "w:gz") as archive:
                 for name in (
-                    "marvisx_cli-0.4.1/PKG-INFO",
-                    "marvisx_cli-0.4.1/marvisx_cli.egg-info/PKG-INFO",
+                    "marvisx_cli-0.4.2/PKG-INFO",
+                    "marvisx_cli-0.4.2/marvisx_cli.egg-info/PKG-INFO",
                 ):
                     info = tarfile.TarInfo(name)
                     info.size = len(metadata)
                     archive.addfile(info, io.BytesIO(metadata))
             self.assertEqual(
                 candidate._distribution_metadata(archive_path),
-                ("marvisx-cli", "0.4.1"),
+                ("marvisx-cli", "0.4.2"),
             )
 
     def test_manifest_rejects_unmanifested_release_asset(self) -> None:
@@ -1069,11 +1079,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.1",
+                version="0.4.2",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.1"},
+                "info": {"name": "marvisx-cli", "version": "0.4.2"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1100,11 +1110,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.1",
+                version="0.4.2",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.1"},
+                "info": {"name": "marvisx-cli", "version": "0.4.2"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1130,13 +1140,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.1",
+                version="0.4.2",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.1"},
+                "info": {"name": "marvisx-cli", "version": "0.4.2"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1182,7 +1192,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 self.write_manifest(
                     manifest_path,
                     package="marvisx-cli",
-                    version="0.4.1",
+                    version="0.4.2",
                     artifacts=[
                         {
                             "filename": "a.whl",
@@ -1192,7 +1202,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     ],
                 )
                 payload = {
-                    "info": {"name": "marvisx-cli", "version": "0.4.1"},
+                    "info": {"name": "marvisx-cli", "version": "0.4.2"},
                     "urls": [
                         {
                             "filename": "a.whl",
@@ -1230,13 +1240,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.1",
+                version="0.4.2",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.1"},
+                "info": {"name": "marvisx-cli", "version": "0.4.2"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1281,7 +1291,7 @@ class ReleaseCandidateTests(unittest.TestCase):
             spec = types.SimpleNamespace(name="_test_upgrade_verifier", loader=loader)
 
             class Distribution:
-                version = "0.4.1"
+                version = "0.4.2"
 
                 @staticmethod
                 def locate_file(_value):
@@ -1312,7 +1322,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     evidence_dir=Path(raw) / "evidence",
                 )
             self.assertEqual(report["candidate_import_origin"], "installed_distribution")
-            self.assertEqual(report["candidate_distribution_version"], "0.4.1")
+            self.assertEqual(report["candidate_distribution_version"], "0.4.2")
 
     def test_release_entrypoint_does_not_import_build_only_packaging_eagerly(self) -> None:
         with tempfile.TemporaryDirectory(prefix="blocked-packaging-") as raw:
@@ -1631,7 +1641,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 "head_sha": "a" * 40,
                 "path": str(candidate.WORKFLOW_PATH),
                 "event": "push",
-                "head_branch": "v0.4.2",
+                "head_branch": "v0.4.3",
                 "head_repository": {"full_name": policy["repository"]},
             }
             with mock.patch.object(


### PR DESCRIPTION
Marvis task: `3d424629-af9c-43e5-9810-c78688f0727c`

## Outcome

- burns the unpublished immutable `v0.4.1` attempt and moves the candidate to `0.4.2`;
- isolates release unit tests from live GitHub tag variables;
- makes failed-release containment branch on the GitHub API exit status before reading release state;
- records accurate historical and recovery release notes.

## Local verification

- 67/67 release tests in normal context;
- 67/67 release tests under simulated `v0.4.2` tag context;
- checked CI contract: 230 unittest + 444 API pytest + 32 CLI pytest, all green;
- desktop UI: 164 tests, types, production audit and production build green;
- upgrade/backup/restore/rollback from public `0.3.8` green;
- all four public/local surface validators green.

No tag, GitHub Release, PyPI publication, deploy or manual workflow dispatch is part of this PR.