### PR TITLE
fix(release): recover immutable OSS 0.4.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -570,6 +570,12 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Check out the failed immutable tag
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 1
+          ref: ${{ github.ref }}
+
       - name: Keep any failed release visibly non-final
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,25 @@ This project uses strict Semantic Versioning: `MAJOR.MINOR.PATCH`.
 
 No changes yet.
 
-## [0.4.2] - candidate
+## [0.4.3] - candidate
+
+Recovery candidate for the same reviewed public/shared source as 0.4.2. It
+keeps product behavior unchanged and repairs only the immutable release path.
+
+### Fixed
+
+- Isolated unit tests from both CI tag variables and real tags already present
+  in the shared Git object store.
+- Checked out the immutable tag before failed-release containment so GitHub can
+  verify the existing tag without creating or moving one.
+- Recorded every failed immutable version explicitly; 0.4.1 and 0.4.2 cannot
+  be reused.
+
+This section describes a release candidate only. Version 0.4.3 is not
+published until the separate tag, PyPI and post-publication acceptance gates
+all succeed.
+
+## [0.4.2] - 2026-08-31 (failed, not published)
 
 Security and provenance refresh based on the exact merged Plan B product base
 and the separately pinned CI evidence foundation from PR #61. The release
@@ -26,16 +44,18 @@ shared engine and its regression coverage.
   database migrations and temporary compatibility tombstones remain.
 - Expanded Python 3.10-3.13, Linux, macOS and Windows install and upgrade proof.
 
-### Fixed
+### Attempted fixes
 
 - Isolated release unit tests from live GitHub tag variables so a tag run does
   not accidentally enter publication mode.
 - Made failed GitHub Release lookups branch on the API exit status instead of
   treating an error payload as an existing final release.
 
-This section describes a release candidate only. Version 0.4.2 is not
-published until the separate tag, PyPI and post-publication acceptance gates
-all succeed.
+The immutable tag exists, but the tag workflow stopped before the package
+build. Unit tests were isolated from CI variables but still observed the real
+tag in the shared Git object store. Failed-release containment then lacked a
+Git checkout. No GitHub Release or PyPI file was created. Version 0.4.2 is
+burned and must never be reused.
 
 ## [0.4.1] - 2026-08-31 (failed, not published)
 

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -24,9 +24,13 @@
   "candidate_state": {
     "status": "active"
   },
-  "candidate_version": "0.4.2",
-  "candidate_tag": "v0.4.2",
+  "candidate_version": "0.4.3",
+  "candidate_tag": "v0.4.3",
   "historical_failed_version": "0.4.1",
+  "historical_failed_versions": [
+    "0.4.1",
+    "0.4.2"
+  ],
   "approval_deadline_hours": 24,
   "allowed_release_delta": [
     ".github/workflows/release.yml",
@@ -59,7 +63,7 @@
     "repository": "emiliomartucci/marvis",
     "workflow": "release.yml",
     "environment": "pypi",
-    "candidate_tag": "v0.4.2",
+    "candidate_tag": "v0.4.3",
     "write_authority_canary_workflow": "watchdog-canary.yml",
     "approval_deadline_hours": 24,
     "late_approval_upload_guard": true

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -3,7 +3,7 @@
 > Historical failed attempt. The immutable `v0.4.1` tag exists, but its tag
 > workflow stopped before the package build. No GitHub Release or PyPI file was
 > created. This version is burned and must not be reused; the recovery release
-> is `0.4.2`.
+> is `0.4.3` after a second burned attempt at `0.4.2`.
 
 This release projects the verified public/shared Marvis engine refresh into the
 local single-user product while preserving its CLI, MCP, hooks, local GUI and
@@ -40,7 +40,9 @@ software and all public descriptions remain bounded by the current BSL terms.
 Publication status: failed historical attempt, not a published release. The
 annotated tag exists and remains immutable. The tag workflow stopped before the
 package build because unit tests inherited the live GitHub tag context. No
-GitHub Release or PyPI file was created. Recovery continues only as `0.4.2`.
+GitHub Release or PyPI file was created. Recovery continues only as `0.4.3`;
+`0.4.2` is also immutable and unpublished after a separate release-path
+failure.
 
 The dated namespace and failed-release evidence is recorded in
 [`2026-08-28-public-release-preflight.md`](2026-08-28-public-release-preflight.md).

--- a/docs/releases/0.4.3.md
+++ b/docs/releases/0.4.3.md
@@ -1,10 +1,4 @@
-# marvisx-cli 0.4.2
-
-> Historical failed attempt. The immutable `v0.4.2` tag exists, but its tag
-> workflow stopped before the package build. Unit tests still observed the
-> real tag in the shared Git object store, and the failed-release containment
-> job lacked a Git checkout. No GitHub Release or PyPI file was created. This
-> version is burned and must not be reused; recovery continues as `0.4.3`.
+# marvisx-cli 0.4.3
 
 This recovery release projects the verified public/shared Marvis engine refresh
 into the local single-user product while preserving its CLI, MCP, hooks, local
@@ -26,13 +20,14 @@ Highlights:
 - removal of retired Heypocket, n8n and Reddit runtime integrations while
   retaining historical database migrations and compatibility tombstones.
 
-Versions `0.4.1` and `0.4.2` are burned, unpublished historical attempts. The
-second attempt isolated CI variables and corrected API error branching, but it
-did not isolate real repository tag presence and did not check out Git before
-containment.
+Versions `0.4.1` and `0.4.2` are burned, unpublished historical attempts. This
+candidate additionally isolates unit tests from real tags in the shared Git
+object store and checks out the failed immutable tag before containment.
 
 License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
-Publication status: failed historical attempt, not a published release. The
-annotated tag remains immutable; recovery continues only as `0.4.3`.
+Publication status: active recovery candidate, not yet published. Publication
+requires a successful explicit preflight at the exact merged `main` commit,
+fresh owner receipts, one immutable `v0.4.3` tag build, exact PyPI readback and
+post-publication installation, upgrade and rollback acceptance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marvisx-cli"
-version = "0.4.2"
+version = "0.4.3"
 description = "MarvisX open-core — agent-native company-brain CLI runtime (init, status, brief, triage)"
 # long_description is sourced from this README (rendered on PyPI). BSL-1.1 is
 # source-available; `license` carries the SPDX-style text marker.

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -937,7 +937,18 @@ def validate_static(
         raise ReleasePolicyError("candidate version/tag does not match pyproject")
     if tag_build:
         _validate_tag_trigger(tag, trigger_ref or os.environ.get("GITHUB_REF"))
-    if version == str(policy.get("historical_failed_version") or ""):
+    failed_versions = policy.get("historical_failed_versions")
+    if (
+        not isinstance(failed_versions, list)
+        or not failed_versions
+        or any(not isinstance(item, str) or not item for item in failed_versions)
+        or len(set(failed_versions)) != len(failed_versions)
+    ):
+        raise ReleasePolicyError("historical failed version inventory is invalid")
+    legacy_failed_version = str(policy.get("historical_failed_version") or "")
+    if legacy_failed_version and legacy_failed_version not in failed_versions:
+        raise ReleasePolicyError("historical failed version inventory is incomplete")
+    if version in failed_versions:
         raise ReleasePolicyError("historical failed version cannot be reused")
     changelog = (root / "CHANGELOG.md").read_text(encoding="utf-8")
     if f"## [{version}]" not in changelog:

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -44,6 +44,13 @@ class ReleaseCandidateTests(unittest.TestCase):
         )
         receipt_env.start()
         self.addCleanup(receipt_env.stop)
+        # A real immutable tag may already exist in the shared Git object
+        # store while this suite exercises synthetic candidate states. Keep
+        # unit tests independent from repository release history; dedicated
+        # tests pass explicit tag coordinates to the production validator.
+        tag_lookup = mock.patch.object(candidate, "_tag_target", return_value=None)
+        tag_lookup.start()
+        self.addCleanup(tag_lookup.stop)
 
     def policy(self) -> dict:
         return copy.deepcopy(candidate.load_policy(ROOT))
@@ -64,13 +71,13 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def write_release_artifacts(self, dist: Path) -> tuple[Path, Path]:
         dist.mkdir(parents=True, exist_ok=True)
-        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.2\n\n"
-        wheel = dist / "marvisx_cli-0.4.2-py3-none-any.whl"
+        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.3\n\n"
+        wheel = dist / "marvisx_cli-0.4.3-py3-none-any.whl"
         with zipfile.ZipFile(wheel, "w") as archive:
-            archive.writestr("marvisx_cli-0.4.2.dist-info/METADATA", metadata)
-        sdist = dist / "marvisx_cli-0.4.2.tar.gz"
+            archive.writestr("marvisx_cli-0.4.3.dist-info/METADATA", metadata)
+        sdist = dist / "marvisx_cli-0.4.3.tar.gz"
         with tarfile.open(sdist, "w:gz") as archive:
-            info = tarfile.TarInfo("marvisx_cli-0.4.2/PKG-INFO")
+            info = tarfile.TarInfo("marvisx_cli-0.4.3/PKG-INFO")
             info.size = len(metadata)
             archive.addfile(info, io.BytesIO(metadata))
         return wheel, sdist
@@ -197,7 +204,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_real_release_candidate_static_policy(self) -> None:
         report = candidate.validate_static(ROOT)
         self.assertEqual(report["status"], "static_green_external_gates_open")
-        self.assertEqual(report["version"], "0.4.2")
+        self.assertEqual(report["version"], "0.4.3")
         self.assertEqual(report["release_branch"], "main")
         self.assertEqual(
             report["product_base_sha"],
@@ -263,7 +270,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         scenarios = {
             ("pull_request", "refs/pull/1/merge"): set(),
             ("workflow_dispatch", "refs/heads/main"): set(),
-            ("push", "refs/tags/v0.4.2"): {
+            ("push", "refs/tags/v0.4.3"): {
                 "release-record",
                 "prepublish",
                 "pypi",
@@ -285,6 +292,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.assertEqual(enabled, expected_jobs)
         blocks = candidate._workflow_job_blocks(workflow)
         contain_block = blocks["contain"]
+        self.assertIn(
+            "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
+            contain_block,
+        )
+        self.assertIn("ref: ${{ github.ref }}", contain_block)
         self.assertIn('if release_json="$(gh api', contain_block)
         self.assertNotIn("2>/dev/null || true", contain_block)
         for job in ("release-record", "pypi", "finalize"):
@@ -297,6 +309,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_unit_suite_clears_live_tag_context(self) -> None:
         for variable in ("GITHUB_EVENT_NAME", "GITHUB_REF", "GITHUB_REF_NAME"):
             self.assertEqual(candidate.os.environ.get(variable), "")
+        self.assertIsNone(candidate._tag_target(ROOT, self.policy()["candidate_tag"]))
 
     def test_invalidated_pull_request_skips_every_expensive_release_step(self) -> None:
         workflow = yaml.safe_load((ROOT / candidate.WORKFLOW_PATH).read_text())
@@ -543,7 +556,28 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_tag_build_rejects_another_trigger_tag(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "another-tag"):
-            candidate._validate_tag_trigger("v0.4.2", "refs/tags/another-tag")
+            candidate._validate_tag_trigger("v0.4.3", "refs/tags/another-tag")
+
+    def test_tag_build_accepts_the_exact_candidate_tag(self) -> None:
+        source = str(candidate._git(ROOT, "rev-parse", "HEAD"))
+        with mock.patch.object(candidate, "_tag_target", return_value=source):
+            report = candidate.validate_static(
+                ROOT,
+                tag_build=True,
+                trigger_ref="refs/tags/v0.4.3",
+            )
+        self.assertEqual(report["version"], "0.4.3")
+        self.assertEqual(report["release_source_sha"], source)
+
+    def test_failed_version_inventory_must_include_the_legacy_entry(self) -> None:
+        policy = self.policy()
+        policy["historical_failed_versions"] = ["0.4.2"]
+        with mock.patch.object(
+            candidate,
+            "load_policy",
+            return_value=policy,
+        ), self.assertRaisesRegex(candidate.ReleasePolicyError, "inventory is incomplete"):
+            candidate.validate_static(ROOT)
 
     def test_release_delta_rejects_product_code(self) -> None:
         foundation = candidate._release_foundation_coordinates(ROOT, self.policy())
@@ -577,7 +611,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_candidate_version_must_exceed_all_history(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "above all PyPI"):
             candidate._require_candidate_above_history(
-                self.policy(), ["0.3.8", "0.4.2"], authority="PyPI"
+                self.policy(), ["0.3.8", "0.4.3"], authority="PyPI"
             )
 
     def test_tagged_source_remains_valid_after_release_branch_advances(self) -> None:
@@ -679,7 +713,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         now = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
         policy = self.policy()
         trusted, watchdog = self.external_receipts(now, policy)
-        watchdog["candidate_tag"] = "v0.4.3"
+        watchdog["candidate_tag"] = "v9.9.9"
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "coordinates"):
             candidate._strict_external_receipts(
                 policy,
@@ -953,20 +987,20 @@ class ReleaseCandidateTests(unittest.TestCase):
                 candidate.build_manifest(ROOT, dist, source_sha=base)
 
     def test_sdist_uses_root_metadata_and_ignores_egg_info_copy(self) -> None:
-        metadata = b"Name: marvisx-cli\nVersion: 0.4.2\n\n"
+        metadata = b"Name: marvisx-cli\nVersion: 0.4.3\n\n"
         with tempfile.TemporaryDirectory(prefix="release-sdist-") as raw:
-            archive_path = Path(raw) / "marvisx_cli-0.4.2.tar.gz"
+            archive_path = Path(raw) / "marvisx_cli-0.4.3.tar.gz"
             with tarfile.open(archive_path, "w:gz") as archive:
                 for name in (
-                    "marvisx_cli-0.4.2/PKG-INFO",
-                    "marvisx_cli-0.4.2/marvisx_cli.egg-info/PKG-INFO",
+                    "marvisx_cli-0.4.3/PKG-INFO",
+                    "marvisx_cli-0.4.3/marvisx_cli.egg-info/PKG-INFO",
                 ):
                     info = tarfile.TarInfo(name)
                     info.size = len(metadata)
                     archive.addfile(info, io.BytesIO(metadata))
             self.assertEqual(
                 candidate._distribution_metadata(archive_path),
-                ("marvisx-cli", "0.4.2"),
+                ("marvisx-cli", "0.4.3"),
             )
 
     def test_manifest_rejects_unmanifested_release_asset(self) -> None:
@@ -1079,11 +1113,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.2",
+                version="0.4.3",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.2"},
+                "info": {"name": "marvisx-cli", "version": "0.4.3"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1110,11 +1144,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.2",
+                version="0.4.3",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.2"},
+                "info": {"name": "marvisx-cli", "version": "0.4.3"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1140,13 +1174,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.2",
+                version="0.4.3",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.2"},
+                "info": {"name": "marvisx-cli", "version": "0.4.3"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1192,7 +1226,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 self.write_manifest(
                     manifest_path,
                     package="marvisx-cli",
-                    version="0.4.2",
+                    version="0.4.3",
                     artifacts=[
                         {
                             "filename": "a.whl",
@@ -1202,7 +1236,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     ],
                 )
                 payload = {
-                    "info": {"name": "marvisx-cli", "version": "0.4.2"},
+                    "info": {"name": "marvisx-cli", "version": "0.4.3"},
                     "urls": [
                         {
                             "filename": "a.whl",
@@ -1240,13 +1274,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.2",
+                version="0.4.3",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.2"},
+                "info": {"name": "marvisx-cli", "version": "0.4.3"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1291,7 +1325,7 @@ class ReleaseCandidateTests(unittest.TestCase):
             spec = types.SimpleNamespace(name="_test_upgrade_verifier", loader=loader)
 
             class Distribution:
-                version = "0.4.2"
+                version = "0.4.3"
 
                 @staticmethod
                 def locate_file(_value):
@@ -1322,7 +1356,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     evidence_dir=Path(raw) / "evidence",
                 )
             self.assertEqual(report["candidate_import_origin"], "installed_distribution")
-            self.assertEqual(report["candidate_distribution_version"], "0.4.2")
+            self.assertEqual(report["candidate_distribution_version"], "0.4.3")
 
     def test_release_entrypoint_does_not_import_build_only_packaging_eagerly(self) -> None:
         with tempfile.TemporaryDirectory(prefix="blocked-packaging-") as raw:
@@ -1641,7 +1675,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 "head_sha": "a" * 40,
                 "path": str(candidate.WORKFLOW_PATH),
                 "event": "push",
-                "head_branch": "v0.4.3",
+                "head_branch": "v9.9.9",
                 "head_repository": {"full_name": policy["repository"]},
             }
             with mock.patch.object(


### PR DESCRIPTION
Marvis task: 3d424629-af9c-43e5-9810-c78688f0727c

## Outcome

- keeps v0.4.1 and v0.4.2 immutable and explicitly burned
- isolates release unit tests from real repository tags
- checks out the failed tag before containment
- advances only the release namespace to 0.4.3

## Local verification

- 69 release tests
- 232 unittest + 444 API + 32 CLI tests
- 164 desktop UI tests, typecheck and production build
- 0.3.8 upgrade, backup, restore and rollback
- exact-tag simulation on commit 5b44def1a0a9d7afcd6eb1123f64aa2d3a22b3cc

No tag, release, PyPI upload or deploy is performed by this PR.