### PR TITLE
fix(release): recover immutable OSS 0.4.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,7 @@ jobs:
       - name: Create a draft and upload only manifested files
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,6 +547,7 @@ jobs:
       - name: Publish, read back and finalize the verified GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           gh release upload "$GITHUB_REF_NAME" acceptance/release-acceptance.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,31 @@ This project uses strict Semantic Versioning: `MAJOR.MINOR.PATCH`.
 
 No changes yet.
 
-## [0.4.3] - candidate
+## [0.4.4] - candidate
 
-Recovery candidate for the same reviewed public/shared source as 0.4.2. It
+Recovery candidate for the same reviewed public/shared source as 0.4.3. It
 keeps product behavior unchanged and repairs only the immutable release path.
 
 ### Fixed
 
-- Isolated unit tests from both CI tag variables and real tags already present
-  in the shared Git object store.
-- Checked out the immutable tag before failed-release containment so GitHub can
-  verify the existing tag without creating or moving one.
-- Recorded every failed immutable version explicitly; 0.4.1 and 0.4.2 cannot
-  be reused.
+- Bound the checkout-free draft-release job to the exact GitHub repository so
+  GitHub CLI does not depend on a local Git directory.
+- Added a regression contract for that explicit repository context.
+- Recorded every failed immutable version explicitly; 0.4.1, 0.4.2 and 0.4.3
+  cannot be reused.
 
-This section describes a release candidate only. Version 0.4.3 is not
+This section describes a release candidate only. Version 0.4.4 is not
 published until the separate tag, PyPI and post-publication acceptance gates
 all succeed.
+
+## [0.4.3] - 2026-08-31 (failed, not published)
+
+The exact package candidate built and passed its package checks. The next job
+could not create the draft GitHub Release because its intentionally
+checkout-free environment did not provide GitHub CLI with explicit repository
+context. Automatic containment created a draft prerelease marked
+`FAILED - DO NOT INSTALL`; no files reached PyPI. Version 0.4.3 is burned and
+must never be reused.
 
 ## [0.4.2] - 2026-08-31 (failed, not published)
 

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -24,12 +24,13 @@
   "candidate_state": {
     "status": "active"
   },
-  "candidate_version": "0.4.3",
-  "candidate_tag": "v0.4.3",
+  "candidate_version": "0.4.4",
+  "candidate_tag": "v0.4.4",
   "historical_failed_version": "0.4.1",
   "historical_failed_versions": [
     "0.4.1",
-    "0.4.2"
+    "0.4.2",
+    "0.4.3"
   ],
   "approval_deadline_hours": 24,
   "allowed_release_delta": [
@@ -63,7 +64,7 @@
     "repository": "emiliomartucci/marvis",
     "workflow": "release.yml",
     "environment": "pypi",
-    "candidate_tag": "v0.4.3",
+    "candidate_tag": "v0.4.4",
     "write_authority_canary_workflow": "watchdog-canary.yml",
     "approval_deadline_hours": 24,
     "late_approval_upload_guard": true

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -3,7 +3,7 @@
 > Historical failed attempt. The immutable `v0.4.1` tag exists, but its tag
 > workflow stopped before the package build. No GitHub Release or PyPI file was
 > created. This version is burned and must not be reused; the recovery release
-> is `0.4.3` after a second burned attempt at `0.4.2`.
+> is `0.4.4` after later burned attempts at `0.4.2` and `0.4.3`.
 
 This release projects the verified public/shared Marvis engine refresh into the
 local single-user product while preserving its CLI, MCP, hooks, local GUI and
@@ -40,9 +40,9 @@ software and all public descriptions remain bounded by the current BSL terms.
 Publication status: failed historical attempt, not a published release. The
 annotated tag exists and remains immutable. The tag workflow stopped before the
 package build because unit tests inherited the live GitHub tag context. No
-GitHub Release or PyPI file was created. Recovery continues only as `0.4.3`;
-`0.4.2` is also immutable and unpublished after a separate release-path
-failure.
+GitHub Release or PyPI file was created. Recovery continues only as `0.4.4`;
+`0.4.2` and `0.4.3` are also immutable and unpublished after separate
+release-path failures.
 
 The dated namespace and failed-release evidence is recorded in
 [`2026-08-28-public-release-preflight.md`](2026-08-28-public-release-preflight.md).

--- a/docs/releases/0.4.3.md
+++ b/docs/releases/0.4.3.md
@@ -1,5 +1,11 @@
 # marvisx-cli 0.4.3
 
+> Historical failed attempt. The exact package candidate built successfully,
+> but the checkout-free GitHub Release job lacked explicit repository context.
+> Automatic containment left a draft prerelease marked `FAILED - DO NOT
+> INSTALL`; no package reached PyPI. This version is burned and must not be
+> reused; recovery continues as `0.4.4`.
+
 This recovery release projects the verified public/shared Marvis engine refresh
 into the local single-user product while preserving its CLI, MCP, hooks, local
 GUI and package contracts.
@@ -20,14 +26,13 @@ Highlights:
 - removal of retired Heypocket, n8n and Reddit runtime integrations while
   retaining historical database migrations and compatibility tombstones.
 
-Versions `0.4.1` and `0.4.2` are burned, unpublished historical attempts. This
-candidate additionally isolates unit tests from real tags in the shared Git
-object store and checks out the failed immutable tag before containment.
+Versions `0.4.1`, `0.4.2` and `0.4.3` are burned, unpublished historical
+attempts. This attempt successfully isolated tests and built the package, but
+the following draft-release job could not resolve its GitHub repository.
 
 License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
-Publication status: active recovery candidate, not yet published. Publication
-requires a successful explicit preflight at the exact merged `main` commit,
-fresh owner receipts, one immutable `v0.4.3` tag build, exact PyPI readback and
-post-publication installation, upgrade and rollback acceptance.
+Publication status: failed historical attempt, not a published release. The
+annotated tag remains immutable and the failed draft release remains visibly
+contained. Recovery continues only as `0.4.4`.

--- a/docs/releases/0.4.4.md
+++ b/docs/releases/0.4.4.md
@@ -1,10 +1,4 @@
-# marvisx-cli 0.4.2
-
-> Historical failed attempt. The immutable `v0.4.2` tag exists, but its tag
-> workflow stopped before the package build. Unit tests still observed the
-> real tag in the shared Git object store, and the failed-release containment
-> job lacked a Git checkout. No GitHub Release or PyPI file was created. This
-> version is burned and must not be reused; recovery continues as `0.4.4`.
+# marvisx-cli 0.4.4
 
 This recovery release projects the verified public/shared Marvis engine refresh
 into the local single-user product while preserving its CLI, MCP, hooks, local
@@ -26,13 +20,15 @@ Highlights:
 - removal of retired Heypocket, n8n and Reddit runtime integrations while
   retaining historical database migrations and compatibility tombstones.
 
-Versions `0.4.1` and `0.4.2` are burned, unpublished historical attempts. The
-second attempt isolated CI variables and corrected API error branching, but it
-did not isolate real repository tag presence and did not check out Git before
-containment.
+Versions `0.4.1`, `0.4.2` and `0.4.3` are burned, unpublished historical
+attempts. This candidate keeps privileged release jobs checkout-free while
+binding GitHub CLI explicitly to `emiliomartucci/marvis`, so draft creation no
+longer depends on a local Git directory.
 
 License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
-Publication status: failed historical attempt, not a published release. The
-annotated tag remains immutable; recovery continues only as `0.4.4`.
+Publication status: active recovery candidate, not yet published. Publication
+requires a successful explicit preflight at the exact merged `main` commit,
+fresh owner receipts, one immutable `v0.4.4` tag build, exact PyPI readback and
+post-publication installation, upgrade and rollback acceptance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marvisx-cli"
-version = "0.4.3"
+version = "0.4.4"
 description = "MarvisX open-core — agent-native company-brain CLI runtime (init, status, brief, triage)"
 # long_description is sourced from this README (rendered on PyPI). BSL-1.1 is
 # source-available; `license` carries the SPDX-style text marker.

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -988,6 +988,7 @@ def validate_static(
         "MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT",
         "MARVIS_APPROVAL_WATCHDOG_RECEIPT",
         "MARVIS_SHARED_SOURCE_OWNER_RECEIPT",
+        "GH_REPO: ${{ github.repository }}",
         "environment: pypi",
         "pypa/gh-action-pypi-publish@" + expected_pins.get("pypa/gh-action-pypi-publish", ""),
     )
@@ -1021,6 +1022,7 @@ def validate_static(
         "MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT: ${{ vars.MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT }}",
         "MARVIS_APPROVAL_WATCHDOG_RECEIPT: ${{ vars.MARVIS_APPROVAL_WATCHDOG_RECEIPT }}",
         "MARVIS_SHARED_SOURCE_OWNER_RECEIPT: ${{ vars.MARVIS_SHARED_SOURCE_OWNER_RECEIPT }}",
+        "GH_REPO: ${{ github.repository }}",
         "if: ${{ always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && (needs.build.result != 'success' || needs.release-record.result != 'success' || needs.prepublish.result != 'success' || needs.pypi.result != 'success' || needs.accept.result != 'success' || needs.finalize.result != 'success') }}",
         'echo "::error::Refusing to mutate an already-final GitHub Release."',
         'echo "::error::The failed candidate exists on PyPI; owner verification and yank are required."',

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -1045,6 +1045,12 @@ def validate_static(
     if not contain_guard.startswith("${{ always() && github.event_name == 'push'"):
         raise ReleasePolicyError("contain is not confined to a tag-push event")
     blocks = _workflow_job_blocks(workflow)
+    for repository_bound_job in ("release-record", "finalize"):
+        block = blocks.get(repository_bound_job) or ""
+        if "GH_REPO: ${{ github.repository }}" not in block:
+            raise ReleasePolicyError(
+                f"{repository_bound_job} lacks explicit GitHub repository context"
+            )
     for privileged_job in ("release-record", "pypi", "finalize"):
         block = blocks.get(privileged_job) or ""
         if "actions/checkout@" in block or "scripts/" in block or "pip install" in block:

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -71,13 +71,13 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def write_release_artifacts(self, dist: Path) -> tuple[Path, Path]:
         dist.mkdir(parents=True, exist_ok=True)
-        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.3\n\n"
-        wheel = dist / "marvisx_cli-0.4.3-py3-none-any.whl"
+        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.4\n\n"
+        wheel = dist / "marvisx_cli-0.4.4-py3-none-any.whl"
         with zipfile.ZipFile(wheel, "w") as archive:
-            archive.writestr("marvisx_cli-0.4.3.dist-info/METADATA", metadata)
-        sdist = dist / "marvisx_cli-0.4.3.tar.gz"
+            archive.writestr("marvisx_cli-0.4.4.dist-info/METADATA", metadata)
+        sdist = dist / "marvisx_cli-0.4.4.tar.gz"
         with tarfile.open(sdist, "w:gz") as archive:
-            info = tarfile.TarInfo("marvisx_cli-0.4.3/PKG-INFO")
+            info = tarfile.TarInfo("marvisx_cli-0.4.4/PKG-INFO")
             info.size = len(metadata)
             archive.addfile(info, io.BytesIO(metadata))
         return wheel, sdist
@@ -204,7 +204,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_real_release_candidate_static_policy(self) -> None:
         report = candidate.validate_static(ROOT)
         self.assertEqual(report["status"], "static_green_external_gates_open")
-        self.assertEqual(report["version"], "0.4.3")
+        self.assertEqual(report["version"], "0.4.4")
         self.assertEqual(report["release_branch"], "main")
         self.assertEqual(
             report["product_base_sha"],
@@ -270,7 +270,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         scenarios = {
             ("pull_request", "refs/pull/1/merge"): set(),
             ("workflow_dispatch", "refs/heads/main"): set(),
-            ("push", "refs/tags/v0.4.3"): {
+            ("push", "refs/tags/v0.4.4"): {
                 "release-record",
                 "prepublish",
                 "pypi",
@@ -291,6 +291,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             enabled = mutating if event == "push" and ref.startswith("refs/tags/v") else set()
             self.assertEqual(enabled, expected_jobs)
         blocks = candidate._workflow_job_blocks(workflow)
+        release_record = parsed["jobs"]["release-record"]
+        release_step = next(
+            step
+            for step in release_record["steps"]
+            if step.get("name") == "Create a draft and upload only manifested files"
+        )
+        self.assertEqual(release_step["env"]["GH_REPO"], "${{ github.repository }}")
         contain_block = blocks["contain"]
         self.assertIn(
             "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",
@@ -556,7 +563,7 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_tag_build_rejects_another_trigger_tag(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "another-tag"):
-            candidate._validate_tag_trigger("v0.4.3", "refs/tags/another-tag")
+            candidate._validate_tag_trigger("v0.4.4", "refs/tags/another-tag")
 
     def test_tag_build_accepts_the_exact_candidate_tag(self) -> None:
         source = str(candidate._git(ROOT, "rev-parse", "HEAD"))
@@ -564,14 +571,14 @@ class ReleaseCandidateTests(unittest.TestCase):
             report = candidate.validate_static(
                 ROOT,
                 tag_build=True,
-                trigger_ref="refs/tags/v0.4.3",
+                trigger_ref="refs/tags/v0.4.4",
             )
-        self.assertEqual(report["version"], "0.4.3")
+        self.assertEqual(report["version"], "0.4.4")
         self.assertEqual(report["release_source_sha"], source)
 
     def test_failed_version_inventory_must_include_the_legacy_entry(self) -> None:
         policy = self.policy()
-        policy["historical_failed_versions"] = ["0.4.2"]
+        policy["historical_failed_versions"] = ["0.4.2", "0.4.3"]
         with mock.patch.object(
             candidate,
             "load_policy",
@@ -611,7 +618,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_candidate_version_must_exceed_all_history(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "above all PyPI"):
             candidate._require_candidate_above_history(
-                self.policy(), ["0.3.8", "0.4.3"], authority="PyPI"
+                self.policy(), ["0.3.8", "0.4.4"], authority="PyPI"
             )
 
     def test_tagged_source_remains_valid_after_release_branch_advances(self) -> None:
@@ -987,20 +994,20 @@ class ReleaseCandidateTests(unittest.TestCase):
                 candidate.build_manifest(ROOT, dist, source_sha=base)
 
     def test_sdist_uses_root_metadata_and_ignores_egg_info_copy(self) -> None:
-        metadata = b"Name: marvisx-cli\nVersion: 0.4.3\n\n"
+        metadata = b"Name: marvisx-cli\nVersion: 0.4.4\n\n"
         with tempfile.TemporaryDirectory(prefix="release-sdist-") as raw:
-            archive_path = Path(raw) / "marvisx_cli-0.4.3.tar.gz"
+            archive_path = Path(raw) / "marvisx_cli-0.4.4.tar.gz"
             with tarfile.open(archive_path, "w:gz") as archive:
                 for name in (
-                    "marvisx_cli-0.4.3/PKG-INFO",
-                    "marvisx_cli-0.4.3/marvisx_cli.egg-info/PKG-INFO",
+                    "marvisx_cli-0.4.4/PKG-INFO",
+                    "marvisx_cli-0.4.4/marvisx_cli.egg-info/PKG-INFO",
                 ):
                     info = tarfile.TarInfo(name)
                     info.size = len(metadata)
                     archive.addfile(info, io.BytesIO(metadata))
             self.assertEqual(
                 candidate._distribution_metadata(archive_path),
-                ("marvisx-cli", "0.4.3"),
+                ("marvisx-cli", "0.4.4"),
             )
 
     def test_manifest_rejects_unmanifested_release_asset(self) -> None:
@@ -1113,11 +1120,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.3",
+                version="0.4.4",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.3"},
+                "info": {"name": "marvisx-cli", "version": "0.4.4"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1144,11 +1151,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.3",
+                version="0.4.4",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.3"},
+                "info": {"name": "marvisx-cli", "version": "0.4.4"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1174,13 +1181,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.3",
+                version="0.4.4",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.3"},
+                "info": {"name": "marvisx-cli", "version": "0.4.4"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1226,7 +1233,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 self.write_manifest(
                     manifest_path,
                     package="marvisx-cli",
-                    version="0.4.3",
+                    version="0.4.4",
                     artifacts=[
                         {
                             "filename": "a.whl",
@@ -1236,7 +1243,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     ],
                 )
                 payload = {
-                    "info": {"name": "marvisx-cli", "version": "0.4.3"},
+                    "info": {"name": "marvisx-cli", "version": "0.4.4"},
                     "urls": [
                         {
                             "filename": "a.whl",
@@ -1274,13 +1281,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.3",
+                version="0.4.4",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.3"},
+                "info": {"name": "marvisx-cli", "version": "0.4.4"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1325,7 +1332,7 @@ class ReleaseCandidateTests(unittest.TestCase):
             spec = types.SimpleNamespace(name="_test_upgrade_verifier", loader=loader)
 
             class Distribution:
-                version = "0.4.3"
+                version = "0.4.4"
 
                 @staticmethod
                 def locate_file(_value):
@@ -1356,7 +1363,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     evidence_dir=Path(raw) / "evidence",
                 )
             self.assertEqual(report["candidate_import_origin"], "installed_distribution")
-            self.assertEqual(report["candidate_distribution_version"], "0.4.3")
+            self.assertEqual(report["candidate_distribution_version"], "0.4.4")
 
     def test_release_entrypoint_does_not_import_build_only_packaging_eagerly(self) -> None:
         with tempfile.TemporaryDirectory(prefix="blocked-packaging-") as raw:

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -291,13 +291,17 @@ class ReleaseCandidateTests(unittest.TestCase):
             enabled = mutating if event == "push" and ref.startswith("refs/tags/v") else set()
             self.assertEqual(enabled, expected_jobs)
         blocks = candidate._workflow_job_blocks(workflow)
-        release_record = parsed["jobs"]["release-record"]
-        release_step = next(
-            step
-            for step in release_record["steps"]
-            if step.get("name") == "Create a draft and upload only manifested files"
-        )
-        self.assertEqual(release_step["env"]["GH_REPO"], "${{ github.repository }}")
+        repository_bound_steps = {
+            "release-record": "Create a draft and upload only manifested files",
+            "finalize": "Publish, read back and finalize the verified GitHub Release",
+        }
+        for job_name, step_name in repository_bound_steps.items():
+            step = next(
+                step
+                for step in parsed["jobs"][job_name]["steps"]
+                if step.get("name") == step_name
+            )
+            self.assertEqual(step["env"]["GH_REPO"], "${{ github.repository }}")
         contain_block = blocks["contain"]
         self.assertIn(
             "actions/checkout@11d5960a326750d5838078e36cf38b85af677262",


### PR DESCRIPTION
Task: 3d424629-af9c-43e5-9810-c78688f0727c

The v0.4.3 package build passed, but its checkout-free draft-release job lacked explicit repository context. The failed tag is immutable, the draft release is contained, and PyPI remains untouched.

This successor changes only the release path: it binds GitHub CLI to the exact repository, adds a regression contract, records v0.4.3 as burned, and advances the candidate to 0.4.4.

Local verification: 69 release tests; full CI contract 232 unittest + 444 API + 32 CLI; 164 desktop UI tests; typecheck and production build; production dependency audit zero vulnerabilities; surface registry green. No manual release rerun.