### PR TITLE
fix(release): make draft readback visible for 0.4.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,10 +311,11 @@ jobs:
           remote_tag_sha="$(gh api \
             "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_REF_NAME}" --jq .sha)"
           test "$remote_tag_sha" = "$GITHUB_SHA"
-          release_state="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
-            --jq '[.draft,.prerelease] | @tsv')"
-          test "$release_state" = $'true\ttrue'
+          release_state="$(gh release view "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json tagName,isDraft,isPrerelease \
+            --jq '[.tagName,.isDraft,.isPrerelease] | @tsv')"
+          test "$release_state" = "$GITHUB_REF_NAME"$'\ttrue\ttrue'
           python - \
             release-artifact/release-manifest.json \
             release-artifact/run-readback.json \
@@ -421,7 +422,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir gh-release-readback
-          gh release download "$GITHUB_REF_NAME" --dir gh-release-readback
+          gh release download "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir gh-release-readback
           cmp release-artifact/release-manifest.json gh-release-readback/release-manifest.json
           python scripts/release_candidate.py verify \
             --manifest gh-release-readback/release-manifest.json \
@@ -583,18 +586,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if release_json="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+          if release_json="$(gh release view "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json tagName,isDraft,isPrerelease \
             2>/dev/null)"; then
-            release_state="$(jq -r '[.draft, .prerelease] | @tsv' <<< "$release_json")"
-            IFS=$'\t' read -r draft prerelease <<< "$release_state"
+            release_state="$(jq -r '[.tagName, .isDraft, .isPrerelease] | @tsv' <<< "$release_json")"
+            IFS=$'\t' read -r tag_name draft prerelease <<< "$release_state"
+            test "$tag_name" = "$GITHUB_REF_NAME"
             if [[ "$draft" == "true" ]]; then
               gh release edit "$GITHUB_REF_NAME" \
+                --repo "$GITHUB_REPOSITORY" \
                 --draft=true \
                 --prerelease=true \
                 --title "$GITHUB_REF_NAME [FAILED - DO NOT INSTALL]"
             elif [[ "$prerelease" == "true" ]]; then
               gh release edit "$GITHUB_REF_NAME" \
+                --repo "$GITHUB_REPOSITORY" \
                 --prerelease=true \
                 --title "$GITHUB_REF_NAME [FAILED - DO NOT INSTALL]"
             else
@@ -603,6 +610,7 @@ jobs:
             fi
           else
             gh release create "$GITHUB_REF_NAME" \
+              --repo "$GITHUB_REPOSITORY" \
               --verify-tag \
               --draft \
               --prerelease \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,28 @@ This project uses strict Semantic Versioning: `MAJOR.MINOR.PATCH`.
 
 No changes yet.
 
-## [0.4.4] - candidate
+## [0.4.5] - candidate
+
+Recovery candidate for the same reviewed public/shared source as 0.4.4. It
+keeps product behavior unchanged and repairs only the immutable release path.
+
+### Fixed
+
+- Read draft GitHub Releases from the paginated release inventory instead of
+  the tag lookup endpoint, which intentionally returns 404 for drafts.
+- Made the protected PyPI gate and failed-release containment use the
+  draft-aware GitHub CLI lookup with explicit repository context.
+- Fail closed if the candidate release inventory is missing, duplicated or no
+  longer both draft and prerelease.
+
+This section describes a release candidate only. Version 0.4.5 is not
+published until the separate tag, PyPI and post-publication acceptance gates
+all succeed.
+
+## [0.4.4] - 2026-08-31 (failed, not published)
 
 Recovery candidate for the same reviewed public/shared source as 0.4.3. It
-keeps product behavior unchanged and repairs only the immutable release path.
+kept product behavior unchanged and repaired only the immutable release path.
 
 ### Fixed
 
@@ -21,9 +39,12 @@ keeps product behavior unchanged and repairs only the immutable release path.
 - Recorded every failed immutable version explicitly; 0.4.1, 0.4.2 and 0.4.3
   cannot be reused.
 
-This section describes a release candidate only. Version 0.4.4 is not
-published until the separate tag, PyPI and post-publication acceptance gates
-all succeed.
+The exact package candidate built and the draft GitHub Release was created.
+The protected publication gate then used the release-by-tag API, which returns
+404 for draft releases, and stopped before PyPI. Automatic containment used
+the same draft-blind lookup and created a second empty failed draft. Both
+drafts are visibly contained, no package reached PyPI, and version 0.4.4 is
+burned and must never be reused.
 
 ## [0.4.3] - 2026-08-31 (failed, not published)
 

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -24,13 +24,14 @@
   "candidate_state": {
     "status": "active"
   },
-  "candidate_version": "0.4.4",
-  "candidate_tag": "v0.4.4",
+  "candidate_version": "0.4.5",
+  "candidate_tag": "v0.4.5",
   "historical_failed_version": "0.4.1",
   "historical_failed_versions": [
     "0.4.1",
     "0.4.2",
-    "0.4.3"
+    "0.4.3",
+    "0.4.4"
   ],
   "approval_deadline_hours": 24,
   "allowed_release_delta": [
@@ -64,7 +65,7 @@
     "repository": "emiliomartucci/marvis",
     "workflow": "release.yml",
     "environment": "pypi",
-    "candidate_tag": "v0.4.4",
+    "candidate_tag": "v0.4.5",
     "write_authority_canary_workflow": "watchdog-canary.yml",
     "approval_deadline_hours": 24,
     "late_approval_upload_guard": true

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -3,7 +3,7 @@
 > Historical failed attempt. The immutable `v0.4.1` tag exists, but its tag
 > workflow stopped before the package build. No GitHub Release or PyPI file was
 > created. This version is burned and must not be reused; the recovery release
-> is `0.4.4` after later burned attempts at `0.4.2` and `0.4.3`.
+> is `0.4.5` after later burned attempts at `0.4.2`, `0.4.3` and `0.4.4`.
 
 This release projects the verified public/shared Marvis engine refresh into the
 local single-user product while preserving its CLI, MCP, hooks, local GUI and
@@ -40,8 +40,8 @@ software and all public descriptions remain bounded by the current BSL terms.
 Publication status: failed historical attempt, not a published release. The
 annotated tag exists and remains immutable. The tag workflow stopped before the
 package build because unit tests inherited the live GitHub tag context. No
-GitHub Release or PyPI file was created. Recovery continues only as `0.4.4`;
-`0.4.2` and `0.4.3` are also immutable and unpublished after separate
+GitHub Release or PyPI file was created. Recovery continues only as `0.4.5`;
+`0.4.2`, `0.4.3` and `0.4.4` are also immutable and unpublished after separate
 release-path failures.
 
 The dated namespace and failed-release evidence is recorded in

--- a/docs/releases/0.4.2.md
+++ b/docs/releases/0.4.2.md
@@ -4,7 +4,7 @@
 > workflow stopped before the package build. Unit tests still observed the
 > real tag in the shared Git object store, and the failed-release containment
 > job lacked a Git checkout. No GitHub Release or PyPI file was created. This
-> version is burned and must not be reused; recovery continues as `0.4.4`.
+> version is burned and must not be reused; recovery continues as `0.4.5`.
 
 This recovery release projects the verified public/shared Marvis engine refresh
 into the local single-user product while preserving its CLI, MCP, hooks, local
@@ -35,4 +35,4 @@ License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
 Publication status: failed historical attempt, not a published release. The
-annotated tag remains immutable; recovery continues only as `0.4.4`.
+annotated tag remains immutable; recovery continues only as `0.4.5`.

--- a/docs/releases/0.4.3.md
+++ b/docs/releases/0.4.3.md
@@ -4,7 +4,7 @@
 > but the checkout-free GitHub Release job lacked explicit repository context.
 > Automatic containment left a draft prerelease marked `FAILED - DO NOT
 > INSTALL`; no package reached PyPI. This version is burned and must not be
-> reused; recovery continues as `0.4.4`.
+> reused; recovery continues as `0.4.5`.
 
 This recovery release projects the verified public/shared Marvis engine refresh
 into the local single-user product while preserving its CLI, MCP, hooks, local
@@ -35,4 +35,4 @@ software and all public descriptions remain bounded by the current BSL terms.
 
 Publication status: failed historical attempt, not a published release. The
 annotated tag remains immutable and the failed draft release remains visibly
-contained. Recovery continues only as `0.4.4`.
+contained. Recovery continues only as `0.4.5`.

--- a/docs/releases/0.4.5.md
+++ b/docs/releases/0.4.5.md
@@ -1,13 +1,6 @@
-# marvisx-cli 0.4.4
+# marvisx-cli 0.4.5
 
-> Historical failed attempt. The exact package candidate built and its draft
-> GitHub Release was created, but the protected publication gate could not see
-> that draft through GitHub's release-by-tag API. Automatic containment used
-> the same draft-blind lookup and created a second empty failed draft. No
-> package reached PyPI. This version is burned and must not be reused; recovery
-> continues as `0.4.5`.
-
-This attempted recovery projected the verified public/shared Marvis engine refresh
+This recovery release projects the verified public/shared Marvis engine refresh
 into the local single-user product while preserving its CLI, MCP, hooks, local
 GUI and package contracts.
 
@@ -27,14 +20,16 @@ Highlights:
 - removal of retired Heypocket, n8n and Reddit runtime integrations while
   retaining historical database migrations and compatibility tombstones.
 
-Versions `0.4.1`, `0.4.2` and `0.4.3` were already burned, unpublished
-historical attempts. This candidate kept privileged release jobs checkout-free while
-binding GitHub CLI explicitly to `emiliomartucci/marvis`, so draft creation no
-longer depends on a local Git directory.
+Versions `0.4.1`, `0.4.2`, `0.4.3` and `0.4.4` are burned, unpublished
+historical attempts. This candidate reads draft GitHub Releases from the
+paginated release inventory, makes both the protected publication gate and
+automatic containment use the draft-aware GitHub CLI lookup, and fails closed
+on an absent or ambiguous candidate release.
 
 License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
-Publication status: failed historical attempt, not a published release. The
-annotated tag remains immutable. Both failed drafts remain visibly contained,
-and PyPI has no 0.4.4 files. Recovery continues only as `0.4.5`.
+Publication status: active recovery candidate, not yet published. Publication
+requires a successful explicit preflight at the exact merged `main` commit,
+fresh owner receipts, one immutable `v0.4.5` tag build, exact PyPI readback and
+post-publication installation, upgrade and rollback acceptance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marvisx-cli"
-version = "0.4.4"
+version = "0.4.5"
 description = "MarvisX open-core — agent-native company-brain CLI runtime (init, status, brief, triage)"
 # long_description is sourced from this README (rendered on PyPI). BSL-1.1 is
 # source-available; `license` carries the SPDX-style text marker.

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -1051,6 +1051,20 @@ def validate_static(
             raise ReleasePolicyError(
                 f"{repository_bound_job} lacks explicit GitHub repository context"
             )
+    pypi_block = blocks.get("pypi") or ""
+    contain_block = blocks.get("contain") or ""
+    for job_name, block in (("pypi", pypi_block), ("contain", contain_block)):
+        if (
+            'gh release view "$GITHUB_REF_NAME"' not in block
+            or '--repo "$GITHUB_REPOSITORY"' not in block
+        ):
+            raise ReleasePolicyError(
+                f"{job_name} lacks draft-aware GitHub Release readback"
+            )
+        if "/releases/tags/${GITHUB_REF_NAME}" in block:
+            raise ReleasePolicyError(
+                f"{job_name} uses the draft-blind GitHub Release tag endpoint"
+            )
     for privileged_job in ("release-record", "pypi", "finalize"):
         block = blocks.get(privileged_job) or ""
         if "actions/checkout@" in block or "scripts/" in block or "pip install" in block:
@@ -1100,7 +1114,7 @@ def validate_static(
     }
 
 
-def _request_json(url: str, *, token: str | None = None) -> dict[str, Any]:
+def _request_json_value(url: str, *, token: str | None = None) -> Any:
     headers = {"Accept": "application/vnd.github+json", "User-Agent": "marvis-release-preflight"}
     if token:
         headers["Authorization"] = f"Bearer {token}"
@@ -1115,8 +1129,20 @@ def _request_json(url: str, *, token: str | None = None) -> dict[str, Any]:
         raise ReleasePolicyError(f"remote preflight failed ({exc.code}): {url}") from exc
     except (OSError, json.JSONDecodeError) as exc:
         raise ReleasePolicyError(f"remote preflight unreadable: {url}") from exc
+    return value
+
+
+def _request_json(url: str, *, token: str | None = None) -> dict[str, Any]:
+    value = _request_json_value(url, token=token)
     if not isinstance(value, dict):
         raise ReleasePolicyError(f"remote preflight returned non-object: {url}")
+    return value
+
+
+def _request_json_list(url: str, *, token: str | None = None) -> list[dict[str, Any]]:
+    value = _request_json_value(url, token=token)
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise ReleasePolicyError(f"remote preflight returned non-list: {url}")
     return value
 
 
@@ -1311,19 +1337,39 @@ def _remote_tag_sha(policy: dict[str, Any], *, token: str, api_url: str) -> str:
     return sha
 
 
+def _release_records(
+    policy: dict[str, Any], *, token: str, api_url: str
+) -> list[dict[str, Any]]:
+    repository = str(policy["repository"])
+    tag = str(policy["candidate_tag"])
+    matches: list[dict[str, Any]] = []
+    for page in range(1, 11):
+        releases = _request_json_list(
+            f"{api_url}/repos/{repository}/releases?per_page=100&page={page}",
+            token=token,
+        )
+        matches.extend(release for release in releases if release.get("tag_name") == tag)
+        if len(releases) < 100:
+            return matches
+    raise ReleasePolicyError("GitHub Release inventory exceeds the bounded readback")
+
+
+def _require_release_absence(
+    policy: dict[str, Any], *, token: str, api_url: str
+) -> None:
+    if _release_records(policy, token=token, api_url=api_url):
+        raise ReleasePolicyError("candidate GitHub Release already exists")
+
+
 def _draft_release(
     policy: dict[str, Any], *, token: str, api_url: str
 ) -> dict[str, Any]:
-    repository = str(policy["repository"])
-    tag = str(policy["candidate_tag"])
-    try:
-        release = _request_json(
-            f"{api_url}/repos/{repository}/releases/tags/{tag}", token=token
-        )
-    except FileNotFoundError as exc:
-        raise ReleasePolicyError("contained draft GitHub Release is absent") from exc
-    if release.get("tag_name") != tag:
-        raise ReleasePolicyError("draft GitHub Release names a different tag")
+    matches = _release_records(policy, token=token, api_url=api_url)
+    if not matches:
+        raise ReleasePolicyError("contained draft GitHub Release is absent")
+    if len(matches) != 1:
+        raise ReleasePolicyError("contained draft GitHub Release is ambiguous")
+    release = matches[0]
     if release.get("draft") is not True or release.get("prerelease") is not True:
         raise ReleasePolicyError("GitHub Release became final before registry acceptance")
     return {
@@ -1364,11 +1410,7 @@ def preflight(
         label="candidate Git tag",
         token=token,
     )
-    _require_remote_absence(
-        f"{api_url}/repos/{repository}/releases/tags/{tag}",
-        label="candidate GitHub Release",
-        token=token,
-    )
+    _require_release_absence(policy, token=token, api_url=api_url)
     _require_remote_absence(
         _candidate_pypi_url(policy),
         label="candidate PyPI version",
@@ -1427,13 +1469,7 @@ def tag_preflight(
         token=token,
         api_url=api_url,
     )
-    repository = str(policy["repository"])
-    tag = urllib.parse.quote(str(policy["candidate_tag"]), safe="")
-    _require_remote_absence(
-        f"{api_url}/repos/{repository}/releases/tags/{tag}",
-        label="candidate GitHub Release",
-        token=token,
-    )
+    _require_release_absence(policy, token=token, api_url=api_url)
     _require_remote_absence(
         _candidate_pypi_url(policy),
         label="candidate PyPI version",

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -71,13 +71,13 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def write_release_artifacts(self, dist: Path) -> tuple[Path, Path]:
         dist.mkdir(parents=True, exist_ok=True)
-        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.4\n\n"
-        wheel = dist / "marvisx_cli-0.4.4-py3-none-any.whl"
+        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.5\n\n"
+        wheel = dist / "marvisx_cli-0.4.5-py3-none-any.whl"
         with zipfile.ZipFile(wheel, "w") as archive:
-            archive.writestr("marvisx_cli-0.4.4.dist-info/METADATA", metadata)
-        sdist = dist / "marvisx_cli-0.4.4.tar.gz"
+            archive.writestr("marvisx_cli-0.4.5.dist-info/METADATA", metadata)
+        sdist = dist / "marvisx_cli-0.4.5.tar.gz"
         with tarfile.open(sdist, "w:gz") as archive:
-            info = tarfile.TarInfo("marvisx_cli-0.4.4/PKG-INFO")
+            info = tarfile.TarInfo("marvisx_cli-0.4.5/PKG-INFO")
             info.size = len(metadata)
             archive.addfile(info, io.BytesIO(metadata))
         return wheel, sdist
@@ -204,7 +204,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_real_release_candidate_static_policy(self) -> None:
         report = candidate.validate_static(ROOT)
         self.assertEqual(report["status"], "static_green_external_gates_open")
-        self.assertEqual(report["version"], "0.4.4")
+        self.assertEqual(report["version"], "0.4.5")
         self.assertEqual(report["release_branch"], "main")
         self.assertEqual(
             report["product_base_sha"],
@@ -270,7 +270,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         scenarios = {
             ("pull_request", "refs/pull/1/merge"): set(),
             ("workflow_dispatch", "refs/heads/main"): set(),
-            ("push", "refs/tags/v0.4.4"): {
+            ("push", "refs/tags/v0.4.5"): {
                 "release-record",
                 "prepublish",
                 "pypi",
@@ -308,8 +308,14 @@ class ReleaseCandidateTests(unittest.TestCase):
             contain_block,
         )
         self.assertIn("ref: ${{ github.ref }}", contain_block)
-        self.assertIn('if release_json="$(gh api', contain_block)
+        self.assertIn('if release_json="$(gh release view', contain_block)
+        self.assertIn('--repo "$GITHUB_REPOSITORY"', contain_block)
+        self.assertNotIn("/releases/tags/${GITHUB_REF_NAME}", contain_block)
         self.assertNotIn("2>/dev/null || true", contain_block)
+        pypi_block = blocks["pypi"]
+        self.assertIn('gh release view "$GITHUB_REF_NAME"', pypi_block)
+        self.assertIn('--repo "$GITHUB_REPOSITORY"', pypi_block)
+        self.assertNotIn("/releases/tags/${GITHUB_REF_NAME}", pypi_block)
         for job in ("release-record", "pypi", "finalize"):
             self.assertNotIn("actions/checkout@", blocks[job])
             self.assertNotIn("scripts/", blocks[job])
@@ -567,7 +573,7 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_tag_build_rejects_another_trigger_tag(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "another-tag"):
-            candidate._validate_tag_trigger("v0.4.4", "refs/tags/another-tag")
+            candidate._validate_tag_trigger("v0.4.5", "refs/tags/another-tag")
 
     def test_tag_build_accepts_the_exact_candidate_tag(self) -> None:
         source = str(candidate._git(ROOT, "rev-parse", "HEAD"))
@@ -575,10 +581,66 @@ class ReleaseCandidateTests(unittest.TestCase):
             report = candidate.validate_static(
                 ROOT,
                 tag_build=True,
-                trigger_ref="refs/tags/v0.4.4",
+                trigger_ref="refs/tags/v0.4.5",
             )
-        self.assertEqual(report["version"], "0.4.4")
+        self.assertEqual(report["version"], "0.4.5")
         self.assertEqual(report["release_source_sha"], source)
+
+    def test_draft_release_is_read_from_the_release_inventory(self) -> None:
+        policy = self.policy()
+        release = {
+            "id": 42,
+            "tag_name": policy["candidate_tag"],
+            "draft": True,
+            "prerelease": True,
+        }
+        with mock.patch.object(
+            candidate,
+            "_request_json_list",
+            return_value=[release],
+        ) as request:
+            result = candidate._draft_release(
+                policy,
+                token="masked",
+                api_url="https://api.example",
+            )
+        self.assertEqual(result, release)
+        request.assert_called_once_with(
+            "https://api.example/repos/emiliomartucci/marvis/releases?per_page=100&page=1",
+            token="masked",
+        )
+
+    def test_draft_release_rejects_ambiguous_inventory(self) -> None:
+        policy = self.policy()
+        release = {
+            "id": 42,
+            "tag_name": policy["candidate_tag"],
+            "draft": True,
+            "prerelease": True,
+        }
+        with mock.patch.object(
+            candidate,
+            "_release_records",
+            return_value=[release, {**release, "id": 43}],
+        ), self.assertRaisesRegex(candidate.ReleasePolicyError, "ambiguous"):
+            candidate._draft_release(
+                policy,
+                token="masked",
+                api_url="https://api.example",
+            )
+
+    def test_release_absence_detects_an_existing_draft(self) -> None:
+        policy = self.policy()
+        with mock.patch.object(
+            candidate,
+            "_release_records",
+            return_value=[{"tag_name": policy["candidate_tag"], "draft": True}],
+        ), self.assertRaisesRegex(candidate.ReleasePolicyError, "already exists"):
+            candidate._require_release_absence(
+                policy,
+                token="masked",
+                api_url="https://api.example",
+            )
 
     def test_failed_version_inventory_must_include_the_legacy_entry(self) -> None:
         policy = self.policy()
@@ -622,7 +684,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_candidate_version_must_exceed_all_history(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "above all PyPI"):
             candidate._require_candidate_above_history(
-                self.policy(), ["0.3.8", "0.4.4"], authority="PyPI"
+                self.policy(), ["0.3.8", "0.4.5"], authority="PyPI"
             )
 
     def test_tagged_source_remains_valid_after_release_branch_advances(self) -> None:
@@ -998,20 +1060,20 @@ class ReleaseCandidateTests(unittest.TestCase):
                 candidate.build_manifest(ROOT, dist, source_sha=base)
 
     def test_sdist_uses_root_metadata_and_ignores_egg_info_copy(self) -> None:
-        metadata = b"Name: marvisx-cli\nVersion: 0.4.4\n\n"
+        metadata = b"Name: marvisx-cli\nVersion: 0.4.5\n\n"
         with tempfile.TemporaryDirectory(prefix="release-sdist-") as raw:
-            archive_path = Path(raw) / "marvisx_cli-0.4.4.tar.gz"
+            archive_path = Path(raw) / "marvisx_cli-0.4.5.tar.gz"
             with tarfile.open(archive_path, "w:gz") as archive:
                 for name in (
-                    "marvisx_cli-0.4.4/PKG-INFO",
-                    "marvisx_cli-0.4.4/marvisx_cli.egg-info/PKG-INFO",
+                    "marvisx_cli-0.4.5/PKG-INFO",
+                    "marvisx_cli-0.4.5/marvisx_cli.egg-info/PKG-INFO",
                 ):
                     info = tarfile.TarInfo(name)
                     info.size = len(metadata)
                     archive.addfile(info, io.BytesIO(metadata))
             self.assertEqual(
                 candidate._distribution_metadata(archive_path),
-                ("marvisx-cli", "0.4.4"),
+                ("marvisx-cli", "0.4.5"),
             )
 
     def test_manifest_rejects_unmanifested_release_asset(self) -> None:
@@ -1124,11 +1186,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.4",
+                version="0.4.5",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.4"},
+                "info": {"name": "marvisx-cli", "version": "0.4.5"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1155,11 +1217,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.4",
+                version="0.4.5",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.4"},
+                "info": {"name": "marvisx-cli", "version": "0.4.5"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1185,13 +1247,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.4",
+                version="0.4.5",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.4"},
+                "info": {"name": "marvisx-cli", "version": "0.4.5"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1237,7 +1299,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 self.write_manifest(
                     manifest_path,
                     package="marvisx-cli",
-                    version="0.4.4",
+                    version="0.4.5",
                     artifacts=[
                         {
                             "filename": "a.whl",
@@ -1247,7 +1309,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     ],
                 )
                 payload = {
-                    "info": {"name": "marvisx-cli", "version": "0.4.4"},
+                    "info": {"name": "marvisx-cli", "version": "0.4.5"},
                     "urls": [
                         {
                             "filename": "a.whl",
@@ -1285,13 +1347,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.4",
+                version="0.4.5",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.4"},
+                "info": {"name": "marvisx-cli", "version": "0.4.5"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1336,7 +1398,7 @@ class ReleaseCandidateTests(unittest.TestCase):
             spec = types.SimpleNamespace(name="_test_upgrade_verifier", loader=loader)
 
             class Distribution:
-                version = "0.4.4"
+                version = "0.4.5"
 
                 @staticmethod
                 def locate_file(_value):
@@ -1367,7 +1429,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     evidence_dir=Path(raw) / "evidence",
                 )
             self.assertEqual(report["candidate_import_origin"], "installed_distribution")
-            self.assertEqual(report["candidate_distribution_version"], "0.4.4")
+            self.assertEqual(report["candidate_distribution_version"], "0.4.5")
 
     def test_release_entrypoint_does_not_import_build_only_packaging_eagerly(self) -> None:
         with tempfile.TemporaryDirectory(prefix="blocked-packaging-") as raw:
@@ -1452,12 +1514,22 @@ class ReleaseCandidateTests(unittest.TestCase):
             candidate, "_require_remote_release_source", return_value=reviewed
         ), mock.patch.object(
             candidate, "_registry_history_check", return_value={"info": {"version": "0.3.8"}}
-        ), mock.patch.object(candidate, "_require_remote_absence") as absence:
+        ), mock.patch.object(
+            candidate, "_require_release_absence"
+        ) as release_absence, mock.patch.object(
+            candidate, "_require_remote_absence"
+        ) as absence:
             report = candidate.tag_preflight(
                 ROOT, token="masked", api_url="https://api.example"
             )
         self.assertEqual(report["status"], "tag_preflight_green")
-        self.assertEqual(absence.call_count, 2)
+        release_absence.assert_called_once_with(
+            policy, token="masked", api_url="https://api.example"
+        )
+        absence.assert_called_once_with(
+            candidate._candidate_pypi_url(policy),
+            label="candidate PyPI version",
+        )
 
     def test_preflight_rejects_source_that_is_not_remote_main_head(self) -> None:
         policy = self.verified_external_policy(
@@ -1520,11 +1592,12 @@ class ReleaseCandidateTests(unittest.TestCase):
         ), mock.patch.object(
             candidate, "_registry_history_check", return_value={"info": {"version": "0.3.8"}}
         ), mock.patch.object(
+            candidate, "_request_json_list", return_value=[]
+        ), mock.patch.object(
             candidate,
             "_request_json",
             side_effect=[
                 FileNotFoundError("tag"),
-                FileNotFoundError("release"),
                 FileNotFoundError("pypi"),
             ],
         ):


### PR DESCRIPTION
## Outcome\n\nRepairs the immutable OSS release path for 0.4.5 without changing product behavior.\n\n- reads draft releases from the authenticated paginated inventory\n- uses draft-aware GitHub CLI readback in the protected PyPI gate and containment\n- fails closed on missing or ambiguous candidate release state\n- records 0.4.4 as burned and unpublished\n\nMarvis task: 3d424629-af9c-43e5-9810-c78688f0727c\n\n## Local verification\n\n- 72 release tests\n- 235 script tests\n- 444 API tests\n- 32 CLI tests\n- 164 desktop UI tests\n- typecheck and production build\n- production dependency audit: 0 vulnerabilities\n- surface and desktop-host contracts green\n\nNo tag, release, PyPI upload or workflow dispatch is part of this PR.