### PR TITLE
fix(release): attest contained draft before publishing 0.4.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,95 @@ jobs:
             --prerelease \
             --title "$TAG release candidate" \
             --notes-file release-artifact/release-notes.md
+          gh release view "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,tagName,isDraft,isPrerelease,createdAt,assets \
+            > draft-release-readback.json
+          mkdir -p draft-release
+          python3 - \
+            release-artifact/release-manifest.json \
+            draft-release-readback.json \
+            draft-release/draft-release-receipt.json <<'PY'
+          from datetime import datetime, timezone
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+          import sys
+
+          manifest_path, release_path, output_path = map(Path, sys.argv[1:])
+
+          def sha256(path: Path) -> str:
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          unsigned_manifest = dict(manifest)
+          claimed_manifest = unsigned_manifest.pop("content_digest")
+          canonical_manifest = json.dumps(
+              unsigned_manifest, sort_keys=True, separators=(",", ":")
+          ).encode()
+          assert claimed_manifest == hashlib.sha256(canonical_manifest).hexdigest()
+          assert manifest["release_source_sha"] == os.environ["GITHUB_SHA"]
+          assert manifest["tag"] == os.environ["GITHUB_REF_NAME"]
+
+          release = json.loads(release_path.read_text(encoding="utf-8"))
+          assert isinstance(release["databaseId"], int) and release["databaseId"] > 0
+          assert release["tagName"] == os.environ["GITHUB_REF_NAME"]
+          assert release["isDraft"] is True
+          assert release["isPrerelease"] is True
+
+          expected = {
+              row["filename"]: {"size": row["size"], "sha256": row["sha256"]}
+              for row in manifest["artifacts"]
+          }
+          expected[manifest_path.name] = {
+              "size": manifest_path.stat().st_size,
+              "sha256": sha256(manifest_path),
+          }
+          observed = {}
+          for asset in release["assets"]:
+              assert asset["state"] == "uploaded"
+              digest = str(asset["digest"])
+              assert digest.startswith("sha256:")
+              observed[asset["name"]] = {
+                  "size": asset["size"],
+                  "sha256": digest.removeprefix("sha256:"),
+              }
+          assert observed == expected
+
+          receipt = {
+              "schema": "marvis-draft-release-receipt/v1",
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "release_source_sha": os.environ["GITHUB_SHA"],
+              "tag": os.environ["GITHUB_REF_NAME"],
+              "verified_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+              "release": {
+                  "id": release["databaseId"],
+                  "tag_name": release["tagName"],
+                  "draft": release["isDraft"],
+                  "prerelease": release["isPrerelease"],
+                  "created_at": release["createdAt"],
+              },
+              "assets": [
+                  {"filename": name, **identity}
+                  for name, identity in sorted(observed.items())
+              ],
+          }
+          canonical = json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()
+          receipt["content_digest"] = hashlib.sha256(canonical).hexdigest()
+          output_path.write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+      - name: Upload the immutable draft-release receipt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: immutable-draft-release-receipt
+          path: draft-release/draft-release-receipt.json
+          if-no-files-found: error
+          retention-days: 7
 
   prepublish:
     name: Revalidate before the protected publisher
@@ -272,15 +361,25 @@ jobs:
         with:
           name: immutable-release-candidate
           path: release-artifact
+      - name: Download the immutable draft-release receipt
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: immutable-draft-release-receipt
+          path: draft-release
       - name: Revalidate all external gates before approval
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          python scripts/release_candidate.py pretag
+          python scripts/release_candidate.py pretag \
+            --manifest release-artifact/release-manifest.json \
+            --draft-release-receipt draft-release/draft-release-receipt.json \
+            --run-id "$GITHUB_RUN_ID"
           python scripts/release_candidate.py publish-window \
             --manifest release-artifact/release-manifest.json \
-            --dist release-artifact/packages
+            --dist release-artifact/packages \
+            --draft-release-receipt draft-release/draft-release-receipt.json \
+            --run-id "$GITHUB_RUN_ID"
 
   pypi:
     name: Approve and publish the unchanged candidate
@@ -299,6 +398,11 @@ jobs:
         with:
           name: immutable-release-candidate
           path: release-artifact
+      - name: Download the immutable draft-release receipt
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: immutable-draft-release-receipt
+          path: draft-release
       - name: Minimal post-approval readback without candidate execution
         env:
           GH_TOKEN: ${{ github.token }}
@@ -311,13 +415,9 @@ jobs:
           remote_tag_sha="$(gh api \
             "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_REF_NAME}" --jq .sha)"
           test "$remote_tag_sha" = "$GITHUB_SHA"
-          release_state="$(gh release view "$GITHUB_REF_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json tagName,isDraft,isPrerelease \
-            --jq '[.tagName,.isDraft,.isPrerelease] | @tsv')"
-          test "$release_state" = "$GITHUB_REF_NAME"$'\ttrue\ttrue'
           python - \
             release-artifact/release-manifest.json \
+            draft-release/draft-release-receipt.json \
             release-artifact/run-readback.json \
             release-artifact/environment-readback.json \
             release-artifact/packages <<'PY'
@@ -328,18 +428,58 @@ jobs:
           from pathlib import Path
           import sys
 
-          manifest_path, run_path, environment_path, packages_path = map(Path, sys.argv[1:])
+          manifest_path, draft_receipt_path, run_path, environment_path, packages_path = map(
+              Path, sys.argv[1:]
+          )
           manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-          claimed = manifest.pop("content_digest")
-          canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+          unsigned_manifest = dict(manifest)
+          claimed = unsigned_manifest.pop("content_digest")
+          canonical = json.dumps(
+              unsigned_manifest, sort_keys=True, separators=(",", ":")
+          ).encode()
           assert claimed == hashlib.sha256(canonical).hexdigest()
           assert manifest["release_source_sha"] == os.environ["GITHUB_SHA"]
           assert manifest["tag"] == os.environ["GITHUB_REF_NAME"]
           assert manifest["dispatch_preflight"]["head_sha"] == os.environ["GITHUB_SHA"]
-          receipts = manifest["release_controls"]["external_receipts"]
-          assert receipts and set(receipts) == {"trusted_publisher", "approval_watchdog"}
           now = datetime.now(timezone.utc)
           hours = int(manifest["release_controls"]["approval_deadline_hours"])
+
+          draft_receipt = json.loads(draft_receipt_path.read_text(encoding="utf-8"))
+          unsigned_receipt = dict(draft_receipt)
+          receipt_digest = unsigned_receipt.pop("content_digest")
+          canonical_receipt = json.dumps(
+              unsigned_receipt, sort_keys=True, separators=(",", ":")
+          ).encode()
+          assert receipt_digest == hashlib.sha256(canonical_receipt).hexdigest()
+          assert draft_receipt["schema"] == "marvis-draft-release-receipt/v1"
+          assert draft_receipt["repository"] == os.environ["GITHUB_REPOSITORY"]
+          assert draft_receipt["workflow_run_id"] == os.environ["GITHUB_RUN_ID"]
+          assert draft_receipt["release_source_sha"] == os.environ["GITHUB_SHA"]
+          assert draft_receipt["tag"] == os.environ["GITHUB_REF_NAME"]
+          release = draft_receipt["release"]
+          assert release["tag_name"] == os.environ["GITHUB_REF_NAME"]
+          assert release["draft"] is True and release["prerelease"] is True
+          receipt_time = datetime.fromisoformat(
+              draft_receipt["verified_at"].replace("Z", "+00:00")
+          )
+          assert 0 <= (now - receipt_time).total_seconds() <= hours * 3600
+
+          expected_assets = {
+              row["filename"]: {"size": row["size"], "sha256": row["sha256"]}
+              for row in manifest["artifacts"]
+          }
+          expected_assets[manifest_path.name] = {
+              "size": manifest_path.stat().st_size,
+              "sha256": hashlib.sha256(manifest_path.read_bytes()).hexdigest(),
+          }
+          observed_assets = {
+              row["filename"]: {"size": row["size"], "sha256": row["sha256"]}
+              for row in draft_receipt["assets"]
+          }
+          assert observed_assets == expected_assets
+
+          receipts = manifest["release_controls"]["external_receipts"]
+          assert receipts and set(receipts) == {"trusted_publisher", "approval_watchdog"}
           for receipt in receipts.values():
               verified = datetime.fromisoformat(receipt["verified_at"].replace("Z", "+00:00"))
               assert 0 <= (now - verified).total_seconds() <= hours * 3600
@@ -416,19 +556,19 @@ jobs:
         with:
           name: immutable-release-candidate
           path: release-artifact
+      - name: Download the immutable draft-release receipt
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: immutable-draft-release-receipt
+          path: draft-release
       - name: Re-read PyPI and exercise install, upgrade and recovery
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          mkdir gh-release-readback
-          gh release download "$GITHUB_REF_NAME" \
-            --repo "$GITHUB_REPOSITORY" \
-            --dir gh-release-readback
-          cmp release-artifact/release-manifest.json gh-release-readback/release-manifest.json
           python scripts/release_candidate.py verify \
-            --manifest gh-release-readback/release-manifest.json \
-            --dist gh-release-readback
+            --manifest release-artifact/release-manifest.json \
+            --dist release-artifact/packages
           python scripts/release_candidate.py registry \
             --manifest release-artifact/release-manifest.json
           python scripts/release_candidate.py registry-download \
@@ -521,7 +661,8 @@ jobs:
           python scripts/release_candidate.py acceptance \
             --manifest release-artifact/release-manifest.json \
             --registry-dist pypi-readback \
-            --github-dist gh-release-readback \
+            --github-dist release-artifact/packages \
+            --draft-release-receipt draft-release/draft-release-receipt.json \
             --output release-acceptance.json \
             --run-id "$GITHUB_RUN_ID"
       - name: Upload the read-only acceptance receipt
@@ -535,7 +676,7 @@ jobs:
   finalize:
     name: Publish acceptance evidence and finalize
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-    needs: [build, accept]
+    needs: [build, release-record, accept]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -547,12 +688,109 @@ jobs:
         with:
           name: immutable-release-acceptance
           path: acceptance
+      - name: Download the exact candidate
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: immutable-release-candidate
+          path: release-artifact
+      - name: Download the immutable draft-release receipt
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: immutable-draft-release-receipt
+          path: draft-release
       - name: Publish, read back and finalize the verified GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          gh release view "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json databaseId,tagName,isDraft,isPrerelease,createdAt,assets \
+            > final-draft-readback.json
+          mkdir final-draft-assets
+          gh release download "$GITHUB_REF_NAME" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir final-draft-assets
+          python3 - \
+            release-artifact/release-manifest.json \
+            draft-release/draft-release-receipt.json \
+            final-draft-readback.json \
+            final-draft-assets \
+            release-artifact/packages <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+          import sys
+
+          manifest_path, receipt_path, live_path, live_assets, packages = map(
+              Path, sys.argv[1:]
+          )
+
+          def sha256(path: Path) -> str:
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          unsigned_manifest = dict(manifest)
+          claimed_manifest = unsigned_manifest.pop("content_digest")
+          canonical_manifest = json.dumps(
+              unsigned_manifest, sort_keys=True, separators=(",", ":")
+          ).encode()
+          assert claimed_manifest == hashlib.sha256(canonical_manifest).hexdigest()
+          assert manifest["release_source_sha"] == os.environ["GITHUB_SHA"]
+          assert manifest["tag"] == os.environ["GITHUB_REF_NAME"]
+
+          receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+          unsigned_receipt = dict(receipt)
+          claimed_receipt = unsigned_receipt.pop("content_digest")
+          canonical_receipt = json.dumps(
+              unsigned_receipt, sort_keys=True, separators=(",", ":")
+          ).encode()
+          assert claimed_receipt == hashlib.sha256(canonical_receipt).hexdigest()
+          assert receipt["schema"] == "marvis-draft-release-receipt/v1"
+          assert receipt["repository"] == os.environ["GITHUB_REPOSITORY"]
+          assert receipt["workflow_run_id"] == os.environ["GITHUB_RUN_ID"]
+          assert receipt["release_source_sha"] == os.environ["GITHUB_SHA"]
+          assert receipt["tag"] == os.environ["GITHUB_REF_NAME"]
+
+          live = json.loads(live_path.read_text(encoding="utf-8"))
+          assert live["databaseId"] == receipt["release"]["id"]
+          assert live["tagName"] == receipt["release"]["tag_name"]
+          assert live["isDraft"] is True and live["isPrerelease"] is True
+
+          expected = {
+              row["filename"]: {"size": row["size"], "sha256": row["sha256"]}
+              for row in receipt["assets"]
+          }
+          observed = {}
+          for asset in live["assets"]:
+              assert asset["state"] == "uploaded"
+              digest = str(asset["digest"])
+              assert digest.startswith("sha256:")
+              observed[asset["name"]] = {
+                  "size": asset["size"],
+                  "sha256": digest.removeprefix("sha256:"),
+              }
+          assert observed == expected
+
+          downloaded = {
+              path.name: {"size": path.stat().st_size, "sha256": sha256(path)}
+              for path in live_assets.iterdir()
+              if path.is_file()
+          }
+          assert downloaded == expected
+          candidate = {
+              path.name: {"size": path.stat().st_size, "sha256": sha256(path)}
+              for path in packages.iterdir()
+              if path.is_file()
+          }
+          candidate[manifest_path.name] = {
+              "size": manifest_path.stat().st_size,
+              "sha256": sha256(manifest_path),
+          }
+          assert candidate == expected
+          PY
           gh release upload "$GITHUB_REF_NAME" acceptance/release-acceptance.json
           mkdir acceptance-readback
           gh release download "$GITHUB_REF_NAME" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,30 @@ This project uses strict Semantic Versioning: `MAJOR.MINOR.PATCH`.
 
 No changes yet.
 
-## [0.4.5] - candidate
+## [0.4.6] - candidate
 
-Recovery candidate for the same reviewed public/shared source as 0.4.4. It
+Recovery candidate for the same reviewed public/shared source as 0.4.5. It
 keeps product behavior unchanged and repairs only the immutable release path.
 
 ### Fixed
 
-- Read draft GitHub Releases from the paginated release inventory instead of
-  the tag lookup endpoint, which intentionally returns 404 for drafts.
-- Made the protected PyPI gate and failed-release containment use the
-  draft-aware GitHub CLI lookup with explicit repository context.
-- Fail closed if the candidate release inventory is missing, duplicated or no
-  longer both draft and prerelease.
+- Record the exact contained draft and asset hashes while the source-free job
+  has write authority, then pass that immutable receipt to read-only jobs.
+- Keep checked-out candidate code away from GitHub and PyPI write authority.
+- Re-read the live draft and exact asset bytes in the source-free finalizer
+  before publishing the accepted GitHub Release.
 
-This section describes a release candidate only. Version 0.4.5 is not
+This section describes a release candidate only. Version 0.4.6 is not
 published until the separate tag, PyPI and post-publication acceptance gates
 all succeed.
+
+## [0.4.5] - 2026-08-31 (failed, not published)
+
+The exact package candidate and contained draft GitHub Release were created.
+The following read-only job could not enumerate that draft with GitHub's
+intentionally limited workflow token and stopped before PyPI. Automatic
+containment kept the draft visibly marked `FAILED - DO NOT INSTALL`; no package
+reached PyPI. Version 0.4.5 is burned and must never be reused.
 
 ## [0.4.4] - 2026-08-31 (failed, not published)
 

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -24,14 +24,15 @@
   "candidate_state": {
     "status": "active"
   },
-  "candidate_version": "0.4.5",
-  "candidate_tag": "v0.4.5",
+  "candidate_version": "0.4.6",
+  "candidate_tag": "v0.4.6",
   "historical_failed_version": "0.4.1",
   "historical_failed_versions": [
     "0.4.1",
     "0.4.2",
     "0.4.3",
-    "0.4.4"
+    "0.4.4",
+    "0.4.5"
   ],
   "approval_deadline_hours": 24,
   "allowed_release_delta": [
@@ -65,7 +66,7 @@
     "repository": "emiliomartucci/marvis",
     "workflow": "release.yml",
     "environment": "pypi",
-    "candidate_tag": "v0.4.5",
+    "candidate_tag": "v0.4.6",
     "write_authority_canary_workflow": "watchdog-canary.yml",
     "approval_deadline_hours": 24,
     "late_approval_upload_guard": true

--- a/docs/releases/0.4.6.md
+++ b/docs/releases/0.4.6.md
@@ -1,10 +1,4 @@
-# marvisx-cli 0.4.5
-
-> Historical failed attempt. The exact package candidate and contained draft
-> GitHub Release were created, but the next read-only job could not enumerate
-> that draft with its intentionally limited workflow token. Automatic
-> containment kept the draft visibly failed and no package reached PyPI.
-> Version 0.4.5 is burned; recovery continues as 0.4.6.
+# marvisx-cli 0.4.6
 
 This recovery release projects the verified public/shared Marvis engine refresh
 into the local single-user product while preserving its CLI, MCP, hooks, local
@@ -27,12 +21,16 @@ Highlights:
   retaining historical database migrations and compatibility tombstones.
 
 Versions `0.4.1` through `0.4.5` are burned, unpublished historical attempts.
-This attempt read draft GitHub Releases from the paginated release inventory,
-but the following job's read-only workflow token could not enumerate the draft
-created by the preceding write-authority job.
+This candidate records the exact contained draft and its asset hashes in the
+source-free job that owns GitHub write authority. Read-only verification and
+PyPI publication consume that immutable receipt without gaining draft-release
+write access. The source-free finalizer re-reads the live draft and exact asset
+bytes before making the accepted GitHub Release public.
 
 License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
-Publication status: failed and contained. The immutable tag and failed draft
-remain historical evidence; the version must not be reused.
+Publication status: active recovery candidate, not yet published. Publication
+requires a successful explicit preflight at the exact merged `main` commit,
+fresh owner receipts, one immutable `v0.4.6` tag build, exact PyPI readback and
+post-publication installation, upgrade and rollback acceptance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marvisx-cli"
-version = "0.4.5"
+version = "0.4.6"
 description = "MarvisX open-core — agent-native company-brain CLI runtime (init, status, brief, triage)"
 # long_description is sourced from this README (rendered on PyPI). BSL-1.1 is
 # source-available; `license` carries the SPDX-style text marker.

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -41,6 +41,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 POLICY_SCHEMA = "marvis-public-release-policy/v1"
 MANIFEST_SCHEMA = "marvis-public-release-manifest/v1"
 ACCEPTANCE_SCHEMA = "marvis-public-release-acceptance/v1"
+DRAFT_RELEASE_RECEIPT_SCHEMA = "marvis-draft-release-receipt/v1"
 EXTERNAL_RECEIPT_SCHEMA = "marvis-external-release-receipt/v1"
 WATCHDOG_WRITE_AUTHORITY_SCHEMA = "marvis-watchdog-write-authority/v1"
 POLICY_PATH = Path("contracts/release/public-release-v1.json")
@@ -984,6 +985,9 @@ def validate_static(
         "release_candidate.py tag-preflight",
         "release_candidate.py pretag",
         "release_candidate.py publish-window",
+        "immutable-draft-release-receipt",
+        "draft-release-receipt.json",
+        "--draft-release-receipt",
         "installed-upgrade",
         "MARVIS_PYPI_TRUSTED_PUBLISHER_RECEIPT",
         "MARVIS_APPROVAL_WATCHDOG_RECEIPT",
@@ -1053,7 +1057,8 @@ def validate_static(
             )
     pypi_block = blocks.get("pypi") or ""
     contain_block = blocks.get("contain") or ""
-    for job_name, block in (("pypi", pypi_block), ("contain", contain_block)):
+    for job_name in ("release-record", "finalize", "contain"):
+        block = blocks.get(job_name) or ""
         if (
             'gh release view "$GITHUB_REF_NAME"' not in block
             or '--repo "$GITHUB_REPOSITORY"' not in block
@@ -1065,6 +1070,34 @@ def validate_static(
             raise ReleasePolicyError(
                 f"{job_name} uses the draft-blind GitHub Release tag endpoint"
             )
+    for receipt_bound_job in ("prepublish", "pypi", "accept", "finalize"):
+        block = blocks.get(receipt_bound_job) or ""
+        if (
+            "immutable-draft-release-receipt" not in block
+            or "draft-release-receipt.json" not in block
+        ):
+            raise ReleasePolicyError(
+                f"{receipt_bound_job} lacks the immutable draft-release receipt"
+            )
+    for read_only_job in ("prepublish", "pypi", "accept"):
+        block = blocks.get(read_only_job) or ""
+        if (
+            'gh release view "$GITHUB_REF_NAME"' in block
+            or 'gh release download "$GITHUB_REF_NAME"' in block
+            or "/releases/tags/${GITHUB_REF_NAME}" in block
+        ):
+            raise ReleasePolicyError(
+                f"{read_only_job} performs a live draft read without write authority"
+            )
+    release_record_block = blocks.get("release-record") or ""
+    if (
+        "actions/upload-artifact@" not in release_record_block
+        or "contents: write" not in release_record_block
+    ):
+        raise ReleasePolicyError("release-record does not persist write-authority proof")
+    finalize_block = blocks.get("finalize") or ""
+    if 'gh release download "$GITHUB_REF_NAME"' not in finalize_block:
+        raise ReleasePolicyError("finalize does not re-read exact draft assets")
     for privileged_job in ("release-record", "pypi", "finalize"):
         block = blocks.get(privileged_job) or ""
         if "actions/checkout@" in block or "scripts/" in block or "pip install" in block:
@@ -1380,6 +1413,134 @@ def _draft_release(
     }
 
 
+def _draft_release_receipt(
+    policy: dict[str, Any],
+    manifest_path: Path,
+    receipt_path: Path,
+    *,
+    release_source_sha: str,
+    run_id: str,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Validate the source-free write-authority proof of a contained draft."""
+
+    manifest = _validated_manifest(manifest_path)
+    receipt = _load_json(receipt_path)
+    if manifest_path.name != "release-manifest.json" or not str(run_id).isdigit():
+        raise ReleasePolicyError("draft release receipt input coordinates are invalid")
+    if set(receipt) != {
+        "schema",
+        "repository",
+        "workflow_run_id",
+        "release_source_sha",
+        "tag",
+        "verified_at",
+        "release",
+        "assets",
+        "content_digest",
+    }:
+        raise ReleasePolicyError("draft release receipt shape is invalid")
+    if receipt.get("schema") != DRAFT_RELEASE_RECEIPT_SCHEMA:
+        raise ReleasePolicyError("unsupported draft release receipt")
+    claimed = receipt.get("content_digest")
+    unsigned = dict(receipt)
+    unsigned.pop("content_digest", None)
+    if claimed != _sha_bytes(_canonical(unsigned)):
+        raise ReleasePolicyError("draft release receipt content digest mismatch")
+    if (
+        receipt.get("repository") != policy.get("repository")
+        or receipt.get("workflow_run_id") != str(run_id)
+        or receipt.get("release_source_sha") != release_source_sha
+        or receipt.get("tag") != policy.get("candidate_tag")
+        or manifest.get("release_source_sha") != release_source_sha
+        or manifest.get("tag") != policy.get("candidate_tag")
+    ):
+        raise ReleasePolicyError("draft release receipt coordinates differ")
+
+    try:
+        verified = _parse_time(str(receipt.get("verified_at") or ""))
+    except (TypeError, ValueError) as exc:
+        raise ReleasePolicyError("draft release receipt time is invalid") from exc
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    age = (current - verified).total_seconds()
+    if age < 0 or age > int(policy["approval_deadline_hours"]) * 3600:
+        raise ReleasePolicyError("draft release receipt is stale")
+
+    release = receipt.get("release")
+    if not isinstance(release, dict):
+        raise ReleasePolicyError("draft release receipt has no release identity")
+    if set(release) != {
+        "id",
+        "tag_name",
+        "draft",
+        "prerelease",
+        "created_at",
+    }:
+        raise ReleasePolicyError("draft release receipt identity shape is invalid")
+    release_id = release.get("id")
+    if (
+        not isinstance(release_id, int)
+        or isinstance(release_id, bool)
+        or release_id <= 0
+        or release.get("tag_name") != policy.get("candidate_tag")
+        or release.get("draft") is not True
+        or release.get("prerelease") is not True
+    ):
+        raise ReleasePolicyError("draft release receipt is not contained")
+    try:
+        created = _parse_time(str(release.get("created_at") or ""))
+    except (TypeError, ValueError) as exc:
+        raise ReleasePolicyError("draft release creation time is invalid") from exc
+    creation_age = (verified - created).total_seconds()
+    if creation_age < 0 or creation_age > int(policy["approval_deadline_hours"]) * 3600:
+        raise ReleasePolicyError("draft release receipt creation order is invalid")
+
+    expected = {
+        name: {"size": row["size"], "sha256": row["sha256"]}
+        for name, row in _manifest_artifacts(manifest).items()
+    }
+    expected[manifest_path.name] = {
+        "size": manifest_path.stat().st_size,
+        "sha256": _sha_file(manifest_path),
+    }
+    rows = receipt.get("assets")
+    if not isinstance(rows, list) or not rows:
+        raise ReleasePolicyError("draft release receipt asset inventory is empty")
+    observed: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict) or set(row) != {"filename", "size", "sha256"}:
+            raise ReleasePolicyError("draft release receipt asset inventory is invalid")
+        filename = row.get("filename")
+        size = row.get("size")
+        sha256 = row.get("sha256")
+        if (
+            not isinstance(filename, str)
+            or PurePosixPath(filename).name != filename
+            or filename in observed
+            or not isinstance(size, int)
+            or isinstance(size, bool)
+            or size < 0
+            or not isinstance(sha256, str)
+            or not SHA256.fullmatch(sha256)
+        ):
+            raise ReleasePolicyError("draft release receipt asset inventory is invalid")
+        observed[filename] = {"size": size, "sha256": sha256}
+    if observed != expected:
+        raise ReleasePolicyError("draft release assets differ from immutable manifest")
+    return {
+        "id": release_id,
+        "tag_name": release["tag_name"],
+        "draft": True,
+        "prerelease": True,
+        "created_at": release["created_at"],
+        "verified_at": receipt["verified_at"],
+        "workflow_run_id": str(run_id),
+        "assets": rows,
+        "receipt_sha256": _sha_file(receipt_path),
+        "receipt_content_digest": claimed,
+    }
+
+
 def preflight(
     root: Path, *, token: str, api_url: str = "https://api.github.com"
 ) -> dict[str, Any]:
@@ -1492,7 +1653,15 @@ def tag_preflight(
     return report
 
 
-def pretag(root: Path, *, token: str, api_url: str = "https://api.github.com") -> dict[str, Any]:
+def pretag(
+    root: Path,
+    manifest_path: Path,
+    draft_release_receipt: Path,
+    *,
+    token: str,
+    run_id: str,
+    api_url: str = "https://api.github.com",
+) -> dict[str, Any]:
     report = validate_static(root, tag_build=True)
     policy = load_policy(root)
     _require_release_controls_committed(root, report["release_source_sha"])
@@ -1522,7 +1691,13 @@ def pretag(root: Path, *, token: str, api_url: str = "https://api.github.com") -
         token=token,
         api_url=api_url,
     )
-    release = _draft_release(policy, token=token, api_url=api_url)
+    release = _draft_release_receipt(
+        policy,
+        manifest_path,
+        draft_release_receipt,
+        release_source_sha=report["release_source_sha"],
+        run_id=run_id,
+    )
     _require_remote_absence(
         _candidate_pypi_url(policy),
         label="candidate PyPI version",
@@ -2030,6 +2205,7 @@ def build_acceptance_receipt(
     manifest_path: Path,
     registry_dist: Path,
     github_dist: Path,
+    draft_release_receipt: Path,
     *,
     token: str,
     run_id: str,
@@ -2042,7 +2218,7 @@ def build_acceptance_receipt(
     if not SHA40.fullmatch(source_sha):
         raise ReleasePolicyError("release manifest source is invalid")
     verify_manifest(root, manifest_path, registry_dist)
-    verify_manifest(root, github_dist / manifest_path.name, github_dist)
+    verify_manifest(root, manifest_path, github_dist)
     registry = registry_verify(manifest_path, attempts=1, delay_seconds=0)
     policy = load_policy(root)
     external_receipts = _strict_external_receipts(
@@ -2070,7 +2246,14 @@ def build_acceptance_receipt(
         api_url=api_url,
         allow_branch_advance=True,
     )
-    release = _draft_release(policy, token=token, api_url=api_url)
+    release = _draft_release_receipt(
+        policy,
+        manifest_path,
+        draft_release_receipt,
+        release_source_sha=source_sha,
+        run_id=run_id,
+        now=now,
+    )
     run = _workflow_run_readback(
         policy,
         source_sha,
@@ -2143,6 +2326,7 @@ def publish_window(
     root: Path,
     manifest_path: Path,
     dist: Path,
+    draft_release_receipt: Path,
     *,
     token: str,
     run_id: str,
@@ -2199,7 +2383,14 @@ def publish_window(
         api_url=api_url,
         allow_branch_advance=True,
     )
-    _draft_release(policy, token=token, api_url=api_url)
+    release = _draft_release_receipt(
+        policy,
+        manifest_path,
+        draft_release_receipt,
+        release_source_sha=source_sha,
+        run_id=run_id,
+        now=now,
+    )
     environment = _environment_check(policy, token=token, api_url=api_url)
     verify_manifest(root, manifest_path, dist)
     _require_remote_absence(
@@ -2216,6 +2407,7 @@ def publish_window(
         "release_foundation": release_foundation,
         "shared_source": shared_source,
         "dispatch_preflight": dispatch_preflight,
+        "github_release": release,
         "remote_release_branch_sha": remote_branch_sha,
         "registry_latest": (registry.get("info") or {}).get("version"),
     }
@@ -2234,7 +2426,10 @@ def main(argv: list[str] | None = None) -> int:
     static_parser.add_argument("--tag-build", action="store_true")
     static_parser.add_argument("--trigger-ref")
     pretag_parser = sub.add_parser("pretag")
+    pretag_parser.add_argument("--manifest", type=Path, required=True)
+    pretag_parser.add_argument("--draft-release-receipt", type=Path, required=True)
     pretag_parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
+    pretag_parser.add_argument("--run-id", default=os.environ.get("GITHUB_RUN_ID"))
     tag_preflight_parser = sub.add_parser("tag-preflight")
     tag_preflight_parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
     preflight_parser = sub.add_parser("preflight")
@@ -2256,6 +2451,7 @@ def main(argv: list[str] | None = None) -> int:
     acceptance_parser.add_argument("--manifest", type=Path, required=True)
     acceptance_parser.add_argument("--registry-dist", type=Path, required=True)
     acceptance_parser.add_argument("--github-dist", type=Path, required=True)
+    acceptance_parser.add_argument("--draft-release-receipt", type=Path, required=True)
     acceptance_parser.add_argument("--output", type=Path, required=True)
     acceptance_parser.add_argument(
         "--token", default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
@@ -2264,6 +2460,7 @@ def main(argv: list[str] | None = None) -> int:
     window_parser = sub.add_parser("publish-window")
     window_parser.add_argument("--manifest", type=Path, required=True)
     window_parser.add_argument("--dist", type=Path, required=True)
+    window_parser.add_argument("--draft-release-receipt", type=Path, required=True)
     window_parser.add_argument("--token", default=os.environ.get("GITHUB_TOKEN"))
     window_parser.add_argument("--run-id", default=os.environ.get("GITHUB_RUN_ID"))
     installed_upgrade_parser = sub.add_parser("installed-upgrade")
@@ -2281,9 +2478,17 @@ def main(argv: list[str] | None = None) -> int:
                 trigger_ref=args.trigger_ref,
             )
         elif args.command == "pretag":
-            if not args.token:
-                raise ReleasePolicyError("GITHUB_TOKEN is required for live pretag checks")
-            result = pretag(root, token=args.token)
+            if not args.token or not args.run_id:
+                raise ReleasePolicyError(
+                    "GITHUB_TOKEN and GITHUB_RUN_ID are required for live pretag checks"
+                )
+            result = pretag(
+                root,
+                args.manifest.resolve(),
+                args.draft_release_receipt.resolve(),
+                token=args.token,
+                run_id=args.run_id,
+            )
         elif args.command == "tag-preflight":
             if not args.token:
                 raise ReleasePolicyError(
@@ -2326,6 +2531,7 @@ def main(argv: list[str] | None = None) -> int:
                 args.manifest.resolve(),
                 args.registry_dist.resolve(),
                 args.github_dist.resolve(),
+                args.draft_release_receipt.resolve(),
                 token=args.token,
                 run_id=args.run_id,
             )
@@ -2341,6 +2547,7 @@ def main(argv: list[str] | None = None) -> int:
                 root,
                 args.manifest.resolve(),
                 args.dist.resolve(),
+                args.draft_release_receipt.resolve(),
                 token=args.token,
                 run_id=args.run_id,
             )

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -71,13 +71,13 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def write_release_artifacts(self, dist: Path) -> tuple[Path, Path]:
         dist.mkdir(parents=True, exist_ok=True)
-        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.5\n\n"
-        wheel = dist / "marvisx_cli-0.4.5-py3-none-any.whl"
+        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.6\n\n"
+        wheel = dist / "marvisx_cli-0.4.6-py3-none-any.whl"
         with zipfile.ZipFile(wheel, "w") as archive:
-            archive.writestr("marvisx_cli-0.4.5.dist-info/METADATA", metadata)
-        sdist = dist / "marvisx_cli-0.4.5.tar.gz"
+            archive.writestr("marvisx_cli-0.4.6.dist-info/METADATA", metadata)
+        sdist = dist / "marvisx_cli-0.4.6.tar.gz"
         with tarfile.open(sdist, "w:gz") as archive:
-            info = tarfile.TarInfo("marvisx_cli-0.4.5/PKG-INFO")
+            info = tarfile.TarInfo("marvisx_cli-0.4.6/PKG-INFO")
             info.size = len(metadata)
             archive.addfile(info, io.BytesIO(metadata))
         return wheel, sdist
@@ -204,7 +204,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_real_release_candidate_static_policy(self) -> None:
         report = candidate.validate_static(ROOT)
         self.assertEqual(report["status"], "static_green_external_gates_open")
-        self.assertEqual(report["version"], "0.4.5")
+        self.assertEqual(report["version"], "0.4.6")
         self.assertEqual(report["release_branch"], "main")
         self.assertEqual(
             report["product_base_sha"],
@@ -270,7 +270,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         scenarios = {
             ("pull_request", "refs/pull/1/merge"): set(),
             ("workflow_dispatch", "refs/heads/main"): set(),
-            ("push", "refs/tags/v0.4.5"): {
+            ("push", "refs/tags/v0.4.6"): {
                 "release-record",
                 "prepublish",
                 "pypi",
@@ -313,9 +313,16 @@ class ReleaseCandidateTests(unittest.TestCase):
         self.assertNotIn("/releases/tags/${GITHUB_REF_NAME}", contain_block)
         self.assertNotIn("2>/dev/null || true", contain_block)
         pypi_block = blocks["pypi"]
-        self.assertIn('gh release view "$GITHUB_REF_NAME"', pypi_block)
-        self.assertIn('--repo "$GITHUB_REPOSITORY"', pypi_block)
-        self.assertNotIn("/releases/tags/${GITHUB_REF_NAME}", pypi_block)
+        self.assertNotIn('gh release view "$GITHUB_REF_NAME"', pypi_block)
+        self.assertNotIn('gh release download "$GITHUB_REF_NAME"', pypi_block)
+        for job in ("prepublish", "pypi", "accept"):
+            self.assertIn("immutable-draft-release-receipt", blocks[job])
+            self.assertIn("draft-release-receipt.json", blocks[job])
+            self.assertNotIn('gh release view "$GITHUB_REF_NAME"', blocks[job])
+            self.assertNotIn('gh release download "$GITHUB_REF_NAME"', blocks[job])
+        self.assertIn('gh release view "$GITHUB_REF_NAME"', blocks["release-record"])
+        self.assertIn('gh release view "$GITHUB_REF_NAME"', blocks["finalize"])
+        self.assertIn('gh release download "$GITHUB_REF_NAME"', blocks["finalize"])
         for job in ("release-record", "pypi", "finalize"):
             self.assertNotIn("actions/checkout@", blocks[job])
             self.assertNotIn("scripts/", blocks[job])
@@ -573,7 +580,7 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_tag_build_rejects_another_trigger_tag(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "another-tag"):
-            candidate._validate_tag_trigger("v0.4.5", "refs/tags/another-tag")
+            candidate._validate_tag_trigger("v0.4.6", "refs/tags/another-tag")
 
     def test_tag_build_accepts_the_exact_candidate_tag(self) -> None:
         source = str(candidate._git(ROOT, "rev-parse", "HEAD"))
@@ -581,9 +588,9 @@ class ReleaseCandidateTests(unittest.TestCase):
             report = candidate.validate_static(
                 ROOT,
                 tag_build=True,
-                trigger_ref="refs/tags/v0.4.5",
+                trigger_ref="refs/tags/v0.4.6",
             )
-        self.assertEqual(report["version"], "0.4.5")
+        self.assertEqual(report["version"], "0.4.6")
         self.assertEqual(report["release_source_sha"], source)
 
     def test_draft_release_is_read_from_the_release_inventory(self) -> None:
@@ -628,6 +635,101 @@ class ReleaseCandidateTests(unittest.TestCase):
                 token="masked",
                 api_url="https://api.example",
             )
+
+    def test_draft_release_receipt_binds_exact_manifest_assets(self) -> None:
+        policy = self.policy()
+        now = datetime(2026, 8, 31, 19, 0, tzinfo=timezone.utc)
+        with tempfile.TemporaryDirectory(prefix="draft-release-receipt-") as raw:
+            root = Path(raw)
+            wheel = root / "marvisx_cli-0.4.6-py3-none-any.whl"
+            sdist = root / "marvisx_cli-0.4.6.tar.gz"
+            wheel.write_bytes(b"wheel")
+            sdist.write_bytes(b"sdist")
+            manifest_path = root / "release-manifest.json"
+            self.write_manifest(
+                manifest_path,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                tag=policy["candidate_tag"],
+                artifacts=[
+                    {
+                        "filename": wheel.name,
+                        "size": wheel.stat().st_size,
+                        "sha256": candidate._sha_file(wheel),
+                    },
+                    {
+                        "filename": sdist.name,
+                        "size": sdist.stat().st_size,
+                        "sha256": candidate._sha_file(sdist),
+                    },
+                ],
+            )
+            receipt_path = root / "draft-release-receipt.json"
+            receipt = {
+                "schema": candidate.DRAFT_RELEASE_RECEIPT_SCHEMA,
+                "repository": policy["repository"],
+                "workflow_run_id": "123",
+                "release_source_sha": self.RELEASE_SOURCE_SHA,
+                "tag": policy["candidate_tag"],
+                "verified_at": now.isoformat(),
+                "release": {
+                    "id": 42,
+                    "tag_name": policy["candidate_tag"],
+                    "draft": True,
+                    "prerelease": True,
+                    "created_at": now.isoformat(),
+                },
+                "assets": sorted(
+                    [
+                        {
+                            "filename": wheel.name,
+                            "size": wheel.stat().st_size,
+                            "sha256": candidate._sha_file(wheel),
+                        },
+                        {
+                            "filename": sdist.name,
+                            "size": sdist.stat().st_size,
+                            "sha256": candidate._sha_file(sdist),
+                        },
+                        {
+                            "filename": manifest_path.name,
+                            "size": manifest_path.stat().st_size,
+                            "sha256": candidate._sha_file(manifest_path),
+                        },
+                    ],
+                    key=lambda row: row["filename"],
+                ),
+            }
+            receipt["content_digest"] = candidate._sha_bytes(
+                candidate._canonical(receipt)
+            )
+            receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+
+            report = candidate._draft_release_receipt(
+                policy,
+                manifest_path,
+                receipt_path,
+                release_source_sha=self.RELEASE_SOURCE_SHA,
+                run_id="123",
+                now=now,
+            )
+            self.assertEqual(report["id"], 42)
+            self.assertTrue(report["draft"])
+
+            receipt["assets"][0]["size"] += 1
+            receipt.pop("content_digest")
+            receipt["content_digest"] = candidate._sha_bytes(
+                candidate._canonical(receipt)
+            )
+            receipt_path.write_text(json.dumps(receipt), encoding="utf-8")
+            with self.assertRaisesRegex(candidate.ReleasePolicyError, "assets differ"):
+                candidate._draft_release_receipt(
+                    policy,
+                    manifest_path,
+                    receipt_path,
+                    release_source_sha=self.RELEASE_SOURCE_SHA,
+                    run_id="123",
+                    now=now,
+                )
 
     def test_release_absence_detects_an_existing_draft(self) -> None:
         policy = self.policy()
@@ -684,7 +786,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_candidate_version_must_exceed_all_history(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "above all PyPI"):
             candidate._require_candidate_above_history(
-                self.policy(), ["0.3.8", "0.4.5"], authority="PyPI"
+                self.policy(), ["0.3.8", "0.4.6"], authority="PyPI"
             )
 
     def test_tagged_source_remains_valid_after_release_branch_advances(self) -> None:
@@ -1060,20 +1162,20 @@ class ReleaseCandidateTests(unittest.TestCase):
                 candidate.build_manifest(ROOT, dist, source_sha=base)
 
     def test_sdist_uses_root_metadata_and_ignores_egg_info_copy(self) -> None:
-        metadata = b"Name: marvisx-cli\nVersion: 0.4.5\n\n"
+        metadata = b"Name: marvisx-cli\nVersion: 0.4.6\n\n"
         with tempfile.TemporaryDirectory(prefix="release-sdist-") as raw:
-            archive_path = Path(raw) / "marvisx_cli-0.4.5.tar.gz"
+            archive_path = Path(raw) / "marvisx_cli-0.4.6.tar.gz"
             with tarfile.open(archive_path, "w:gz") as archive:
                 for name in (
-                    "marvisx_cli-0.4.5/PKG-INFO",
-                    "marvisx_cli-0.4.5/marvisx_cli.egg-info/PKG-INFO",
+                    "marvisx_cli-0.4.6/PKG-INFO",
+                    "marvisx_cli-0.4.6/marvisx_cli.egg-info/PKG-INFO",
                 ):
                     info = tarfile.TarInfo(name)
                     info.size = len(metadata)
                     archive.addfile(info, io.BytesIO(metadata))
             self.assertEqual(
                 candidate._distribution_metadata(archive_path),
-                ("marvisx-cli", "0.4.5"),
+                ("marvisx-cli", "0.4.6"),
             )
 
     def test_manifest_rejects_unmanifested_release_asset(self) -> None:
@@ -1152,7 +1254,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 return_value=manifest["release_source_sha"],
             ), mock.patch.object(
                 candidate,
-                "_draft_release",
+                "_draft_release_receipt",
                 return_value={"id": 1, "draft": True, "prerelease": True},
             ), mock.patch.object(
                 candidate, "_workflow_run_readback", return_value=run
@@ -1164,6 +1266,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     manifest_path,
                     registry_dist,
                     github_dist,
+                    root / "draft-release-receipt.json",
                     token="masked",
                     run_id="123",
                     now=now,
@@ -1186,11 +1289,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.5",
+                version="0.4.6",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.5"},
+                "info": {"name": "marvisx-cli", "version": "0.4.6"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1217,11 +1320,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.5",
+                version="0.4.6",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.5"},
+                "info": {"name": "marvisx-cli", "version": "0.4.6"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1247,13 +1350,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.5",
+                version="0.4.6",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.5"},
+                "info": {"name": "marvisx-cli", "version": "0.4.6"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1299,7 +1402,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 self.write_manifest(
                     manifest_path,
                     package="marvisx-cli",
-                    version="0.4.5",
+                    version="0.4.6",
                     artifacts=[
                         {
                             "filename": "a.whl",
@@ -1309,7 +1412,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     ],
                 )
                 payload = {
-                    "info": {"name": "marvisx-cli", "version": "0.4.5"},
+                    "info": {"name": "marvisx-cli", "version": "0.4.6"},
                     "urls": [
                         {
                             "filename": "a.whl",
@@ -1347,13 +1450,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.5",
+                version="0.4.6",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.5"},
+                "info": {"name": "marvisx-cli", "version": "0.4.6"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1398,7 +1501,7 @@ class ReleaseCandidateTests(unittest.TestCase):
             spec = types.SimpleNamespace(name="_test_upgrade_verifier", loader=loader)
 
             class Distribution:
-                version = "0.4.5"
+                version = "0.4.6"
 
                 @staticmethod
                 def locate_file(_value):
@@ -1429,7 +1532,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     evidence_dir=Path(raw) / "evidence",
                 )
             self.assertEqual(report["candidate_import_origin"], "installed_distribution")
-            self.assertEqual(report["candidate_distribution_version"], "0.4.5")
+            self.assertEqual(report["candidate_distribution_version"], "0.4.6")
 
     def test_release_entrypoint_does_not_import_build_only_packaging_eagerly(self) -> None:
         with tempfile.TemporaryDirectory(prefix="blocked-packaging-") as raw:
@@ -1481,7 +1584,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             candidate, "_remote_tag_sha", return_value="b" * 40
         ):
             with self.assertRaisesRegex(candidate.ReleasePolicyError, "reviewed"):
-                candidate.pretag(ROOT, token="masked")
+                candidate.pretag(
+                    ROOT,
+                    ROOT / "missing-manifest.json",
+                    ROOT / "missing-draft-release-receipt.json",
+                    token="masked",
+                    run_id="123",
+                )
 
     def test_tag_preflight_requires_unused_release_and_pypi_namespaces(self) -> None:
         policy = self.policy()
@@ -1734,6 +1843,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                         ROOT,
                         manifest_path,
                         Path(raw),
+                        Path(raw) / "draft-release-receipt.json",
                         token="masked",
                         run_id="123",
                         now=now,
@@ -1782,6 +1892,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                         ROOT,
                         manifest_path,
                         Path(raw),
+                        Path(raw) / "draft-release-receipt.json",
                         token="masked",
                         run_id="123",
                         now=now,
@@ -1832,7 +1943,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 candidate, "_remote_tag_sha", return_value="a" * 40
             ), mock.patch.object(
                 candidate, "_require_remote_release_source", return_value="a" * 40
-            ), mock.patch.object(candidate, "_draft_release"), mock.patch.object(
+            ), mock.patch.object(candidate, "_draft_release_receipt"), mock.patch.object(
                 candidate, "_environment_check", return_value={"name": "pypi"}
             ), mock.patch.object(candidate, "verify_manifest"), mock.patch.object(
                 candidate,
@@ -1844,6 +1955,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                         ROOT,
                         manifest_path,
                         Path(raw),
+                        Path(raw) / "draft-release-receipt.json",
                         token="masked",
                         run_id="123",
                         now=now,


### PR DESCRIPTION
Task: 3d424629-af9c-43e5-9810-c78688f0727c

Recovers the burned 0.4.5 attempt as 0.4.6 without widening privileges. The source-free write-authority job records the contained draft and exact asset hashes; read-only jobs validate that immutable receipt; the source-free finalizer live-downloads the same bytes before publication.

Local verification:
- CI collection contract: 236 unittest, 444 API, 32 CLI, all green
- release candidate suite: 73/73 green
- workflow YAML and embedded Python syntax green
- static release policy and diff checks green

This PR stays draft until its single CI set is reviewed.