### PR TITLE
fix(release): isolate immutable receipt for 0.4.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,7 +365,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: immutable-draft-release-receipt
-          path: draft-release
+          path: ${{ runner.temp }}/draft-release
       - name: Revalidate all external gates before approval
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -373,12 +373,12 @@ jobs:
           set -euo pipefail
           python scripts/release_candidate.py pretag \
             --manifest release-artifact/release-manifest.json \
-            --draft-release-receipt draft-release/draft-release-receipt.json \
+            --draft-release-receipt "$RUNNER_TEMP/draft-release/draft-release-receipt.json" \
             --run-id "$GITHUB_RUN_ID"
           python scripts/release_candidate.py publish-window \
             --manifest release-artifact/release-manifest.json \
             --dist release-artifact/packages \
-            --draft-release-receipt draft-release/draft-release-receipt.json \
+            --draft-release-receipt "$RUNNER_TEMP/draft-release/draft-release-receipt.json" \
             --run-id "$GITHUB_RUN_ID"
 
   pypi:
@@ -560,7 +560,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: immutable-draft-release-receipt
-          path: draft-release
+          path: ${{ runner.temp }}/draft-release
       - name: Re-read PyPI and exercise install, upgrade and recovery
         env:
           GH_TOKEN: ${{ github.token }}
@@ -662,7 +662,7 @@ jobs:
             --manifest release-artifact/release-manifest.json \
             --registry-dist pypi-readback \
             --github-dist release-artifact/packages \
-            --draft-release-receipt draft-release/draft-release-receipt.json \
+            --draft-release-receipt "$RUNNER_TEMP/draft-release/draft-release-receipt.json" \
             --output release-acceptance.json \
             --run-id "$GITHUB_RUN_ID"
       - name: Upload the read-only acceptance receipt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,29 @@ This project uses strict Semantic Versioning: `MAJOR.MINOR.PATCH`.
 
 No changes yet.
 
-## [0.4.6] - candidate
+## [0.4.7] - candidate
 
-Recovery candidate for the same reviewed public/shared source as 0.4.5. It
+Recovery candidate for the same reviewed public/shared source as 0.4.6. It
 keeps product behavior unchanged and repairs only the immutable release path.
 
 ### Fixed
 
-- Record the exact contained draft and asset hashes while the source-free job
-  has write authority, then pass that immutable receipt to read-only jobs.
-- Keep checked-out candidate code away from GitHub and PyPI write authority.
-- Re-read the live draft and exact asset bytes in the source-free finalizer
-  before publishing the accepted GitHub Release.
+- Store the immutable draft receipt outside checked-out source in every job
+  that executes the release verifier.
+- Keep the source-purity gate strict and add a regression contract that rejects
+  receipts downloaded into the repository checkout.
 
-This section describes a release candidate only. Version 0.4.6 is not
+This section describes a release candidate only. Version 0.4.7 is not
 published until the separate tag, PyPI and post-publication acceptance gates
 all succeed.
+
+## [0.4.6] - 2026-08-31 (failed, not published)
+
+The exact package candidate and contained draft GitHub Release were created.
+The prepublication verifier then correctly rejected an untracked receipt that
+the workflow had downloaded inside the checked-out source tree. Automatic
+containment marked the draft `FAILED - DO NOT INSTALL`; no package reached
+PyPI. Version 0.4.6 is burned and must never be reused.
 
 ## [0.4.5] - 2026-08-31 (failed, not published)
 

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -24,15 +24,16 @@
   "candidate_state": {
     "status": "active"
   },
-  "candidate_version": "0.4.6",
-  "candidate_tag": "v0.4.6",
+  "candidate_version": "0.4.7",
+  "candidate_tag": "v0.4.7",
   "historical_failed_version": "0.4.1",
   "historical_failed_versions": [
     "0.4.1",
     "0.4.2",
     "0.4.3",
     "0.4.4",
-    "0.4.5"
+    "0.4.5",
+    "0.4.6"
   ],
   "approval_deadline_hours": 24,
   "allowed_release_delta": [
@@ -66,7 +67,7 @@
     "repository": "emiliomartucci/marvis",
     "workflow": "release.yml",
     "environment": "pypi",
-    "candidate_tag": "v0.4.6",
+    "candidate_tag": "v0.4.7",
     "write_authority_canary_workflow": "watchdog-canary.yml",
     "approval_deadline_hours": 24,
     "late_approval_upload_guard": true

--- a/docs/releases/0.4.7.md
+++ b/docs/releases/0.4.7.md
@@ -1,10 +1,4 @@
-# marvisx-cli 0.4.6
-
-> Historical failed attempt. The package candidate and contained draft GitHub
-> Release were created, but the next verifier correctly rejected a receipt
-> downloaded inside the checked-out source tree. Automatic containment marked
-> the draft visibly failed and no package reached PyPI. Version 0.4.6 is burned;
-> recovery continues as 0.4.7.
+# marvisx-cli 0.4.7
 
 This recovery release projects the verified public/shared Marvis engine refresh
 into the local single-user product while preserving its CLI, MCP, hooks, local
@@ -27,12 +21,14 @@ Highlights:
   retaining historical database migrations and compatibility tombstones.
 
 Versions `0.4.1` through `0.4.6` are burned, unpublished historical attempts.
-This attempt recorded the exact contained draft and its asset hashes, but the
-following checked-out job downloaded that receipt into the source tree before
-running the strict source-purity check.
+This candidate keeps the immutable draft receipt outside checked-out source in
+every job that executes the release verifier. The strict source-purity gate
+remains unchanged and now rejects any regression to an in-checkout receipt.
 
 License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
-Publication status: failed and contained. The immutable tag and failed draft
-remain historical evidence; the version must not be reused.
+Publication status: active recovery candidate, not yet published. Publication
+requires a successful explicit preflight at the exact merged `main` commit,
+fresh owner receipts, one immutable `v0.4.7` tag build, exact PyPI readback and
+post-publication installation, upgrade and rollback acceptance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "marvisx-cli"
-version = "0.4.6"
+version = "0.4.7"
 description = "MarvisX open-core — agent-native company-brain CLI runtime (init, status, brief, triage)"
 # long_description is sourced from this README (rendered on PyPI). BSL-1.1 is
 # source-available; `license` carries the SPDX-style text marker.

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -1079,6 +1079,16 @@ def validate_static(
             raise ReleasePolicyError(
                 f"{receipt_bound_job} lacks the immutable draft-release receipt"
             )
+    for checkout_receipt_job in ("prepublish", "accept"):
+        block = blocks.get(checkout_receipt_job) or ""
+        if (
+            "path: ${{ runner.temp }}/draft-release" not in block
+            or '"$RUNNER_TEMP/draft-release/draft-release-receipt.json"' not in block
+            or "path: draft-release\n" in block
+        ):
+            raise ReleasePolicyError(
+                f"{checkout_receipt_job} does not isolate the draft receipt from source"
+            )
     for read_only_job in ("prepublish", "pypi", "accept"):
         block = blocks.get(read_only_job) or ""
         if (

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -71,13 +71,13 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def write_release_artifacts(self, dist: Path) -> tuple[Path, Path]:
         dist.mkdir(parents=True, exist_ok=True)
-        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.6\n\n"
-        wheel = dist / "marvisx_cli-0.4.6-py3-none-any.whl"
+        metadata = b"Metadata-Version: 2.1\nName: marvisx-cli\nVersion: 0.4.7\n\n"
+        wheel = dist / "marvisx_cli-0.4.7-py3-none-any.whl"
         with zipfile.ZipFile(wheel, "w") as archive:
-            archive.writestr("marvisx_cli-0.4.6.dist-info/METADATA", metadata)
-        sdist = dist / "marvisx_cli-0.4.6.tar.gz"
+            archive.writestr("marvisx_cli-0.4.7.dist-info/METADATA", metadata)
+        sdist = dist / "marvisx_cli-0.4.7.tar.gz"
         with tarfile.open(sdist, "w:gz") as archive:
-            info = tarfile.TarInfo("marvisx_cli-0.4.6/PKG-INFO")
+            info = tarfile.TarInfo("marvisx_cli-0.4.7/PKG-INFO")
             info.size = len(metadata)
             archive.addfile(info, io.BytesIO(metadata))
         return wheel, sdist
@@ -204,7 +204,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_real_release_candidate_static_policy(self) -> None:
         report = candidate.validate_static(ROOT)
         self.assertEqual(report["status"], "static_green_external_gates_open")
-        self.assertEqual(report["version"], "0.4.6")
+        self.assertEqual(report["version"], "0.4.7")
         self.assertEqual(report["release_branch"], "main")
         self.assertEqual(
             report["product_base_sha"],
@@ -270,7 +270,7 @@ class ReleaseCandidateTests(unittest.TestCase):
         scenarios = {
             ("pull_request", "refs/pull/1/merge"): set(),
             ("workflow_dispatch", "refs/heads/main"): set(),
-            ("push", "refs/tags/v0.4.6"): {
+            ("push", "refs/tags/v0.4.7"): {
                 "release-record",
                 "prepublish",
                 "pypi",
@@ -320,6 +320,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.assertIn("draft-release-receipt.json", blocks[job])
             self.assertNotIn('gh release view "$GITHUB_REF_NAME"', blocks[job])
             self.assertNotIn('gh release download "$GITHUB_REF_NAME"', blocks[job])
+        for job in ("prepublish", "accept"):
+            self.assertIn("path: ${{ runner.temp }}/draft-release", blocks[job])
+            self.assertIn(
+                '"$RUNNER_TEMP/draft-release/draft-release-receipt.json"',
+                blocks[job],
+            )
+            self.assertNotIn("path: draft-release\n", blocks[job])
         self.assertIn('gh release view "$GITHUB_REF_NAME"', blocks["release-record"])
         self.assertIn('gh release view "$GITHUB_REF_NAME"', blocks["finalize"])
         self.assertIn('gh release download "$GITHUB_REF_NAME"', blocks["finalize"])
@@ -580,7 +587,7 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_tag_build_rejects_another_trigger_tag(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "another-tag"):
-            candidate._validate_tag_trigger("v0.4.6", "refs/tags/another-tag")
+            candidate._validate_tag_trigger("v0.4.7", "refs/tags/another-tag")
 
     def test_tag_build_accepts_the_exact_candidate_tag(self) -> None:
         source = str(candidate._git(ROOT, "rev-parse", "HEAD"))
@@ -588,9 +595,9 @@ class ReleaseCandidateTests(unittest.TestCase):
             report = candidate.validate_static(
                 ROOT,
                 tag_build=True,
-                trigger_ref="refs/tags/v0.4.6",
+                trigger_ref="refs/tags/v0.4.7",
             )
-        self.assertEqual(report["version"], "0.4.6")
+        self.assertEqual(report["version"], "0.4.7")
         self.assertEqual(report["release_source_sha"], source)
 
     def test_draft_release_is_read_from_the_release_inventory(self) -> None:
@@ -641,8 +648,8 @@ class ReleaseCandidateTests(unittest.TestCase):
         now = datetime(2026, 8, 31, 19, 0, tzinfo=timezone.utc)
         with tempfile.TemporaryDirectory(prefix="draft-release-receipt-") as raw:
             root = Path(raw)
-            wheel = root / "marvisx_cli-0.4.6-py3-none-any.whl"
-            sdist = root / "marvisx_cli-0.4.6.tar.gz"
+            wheel = root / "marvisx_cli-0.4.7-py3-none-any.whl"
+            sdist = root / "marvisx_cli-0.4.7.tar.gz"
             wheel.write_bytes(b"wheel")
             sdist.write_bytes(b"sdist")
             manifest_path = root / "release-manifest.json"
@@ -786,7 +793,7 @@ class ReleaseCandidateTests(unittest.TestCase):
     def test_candidate_version_must_exceed_all_history(self) -> None:
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "above all PyPI"):
             candidate._require_candidate_above_history(
-                self.policy(), ["0.3.8", "0.4.6"], authority="PyPI"
+                self.policy(), ["0.3.8", "0.4.7"], authority="PyPI"
             )
 
     def test_tagged_source_remains_valid_after_release_branch_advances(self) -> None:
@@ -1162,20 +1169,20 @@ class ReleaseCandidateTests(unittest.TestCase):
                 candidate.build_manifest(ROOT, dist, source_sha=base)
 
     def test_sdist_uses_root_metadata_and_ignores_egg_info_copy(self) -> None:
-        metadata = b"Name: marvisx-cli\nVersion: 0.4.6\n\n"
+        metadata = b"Name: marvisx-cli\nVersion: 0.4.7\n\n"
         with tempfile.TemporaryDirectory(prefix="release-sdist-") as raw:
-            archive_path = Path(raw) / "marvisx_cli-0.4.6.tar.gz"
+            archive_path = Path(raw) / "marvisx_cli-0.4.7.tar.gz"
             with tarfile.open(archive_path, "w:gz") as archive:
                 for name in (
-                    "marvisx_cli-0.4.6/PKG-INFO",
-                    "marvisx_cli-0.4.6/marvisx_cli.egg-info/PKG-INFO",
+                    "marvisx_cli-0.4.7/PKG-INFO",
+                    "marvisx_cli-0.4.7/marvisx_cli.egg-info/PKG-INFO",
                 ):
                     info = tarfile.TarInfo(name)
                     info.size = len(metadata)
                     archive.addfile(info, io.BytesIO(metadata))
             self.assertEqual(
                 candidate._distribution_metadata(archive_path),
-                ("marvisx-cli", "0.4.6"),
+                ("marvisx-cli", "0.4.7"),
             )
 
     def test_manifest_rejects_unmanifested_release_asset(self) -> None:
@@ -1289,11 +1296,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.6",
+                version="0.4.7",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.6"},
+                "info": {"name": "marvisx-cli", "version": "0.4.7"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1320,11 +1327,11 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.6",
+                version="0.4.7",
                 artifacts=[{"filename": "a.whl", "size": 7, "sha256": "a" * 64}],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.6"},
+                "info": {"name": "marvisx-cli", "version": "0.4.7"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1350,13 +1357,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.6",
+                version="0.4.7",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.6"},
+                "info": {"name": "marvisx-cli", "version": "0.4.7"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1402,7 +1409,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                 self.write_manifest(
                     manifest_path,
                     package="marvisx-cli",
-                    version="0.4.6",
+                    version="0.4.7",
                     artifacts=[
                         {
                             "filename": "a.whl",
@@ -1412,7 +1419,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     ],
                 )
                 payload = {
-                    "info": {"name": "marvisx-cli", "version": "0.4.6"},
+                    "info": {"name": "marvisx-cli", "version": "0.4.7"},
                     "urls": [
                         {
                             "filename": "a.whl",
@@ -1450,13 +1457,13 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.write_manifest(
                 manifest_path,
                 package="marvisx-cli",
-                version="0.4.6",
+                version="0.4.7",
                 artifacts=[
                     {"filename": "a.whl", "size": len(raw_artifact), "sha256": sha256}
                 ],
             )
             payload = {
-                "info": {"name": "marvisx-cli", "version": "0.4.6"},
+                "info": {"name": "marvisx-cli", "version": "0.4.7"},
                 "urls": [
                     {
                         "filename": "a.whl",
@@ -1501,7 +1508,7 @@ class ReleaseCandidateTests(unittest.TestCase):
             spec = types.SimpleNamespace(name="_test_upgrade_verifier", loader=loader)
 
             class Distribution:
-                version = "0.4.6"
+                version = "0.4.7"
 
                 @staticmethod
                 def locate_file(_value):
@@ -1532,7 +1539,7 @@ class ReleaseCandidateTests(unittest.TestCase):
                     evidence_dir=Path(raw) / "evidence",
                 )
             self.assertEqual(report["candidate_import_origin"], "installed_distribution")
-            self.assertEqual(report["candidate_distribution_version"], "0.4.6")
+            self.assertEqual(report["candidate_distribution_version"], "0.4.7")
 
     def test_release_entrypoint_does_not_import_build_only_packaging_eagerly(self) -> None:
         with tempfile.TemporaryDirectory(prefix="blocked-packaging-") as raw:


### PR DESCRIPTION
Closes the local source-purity gap found by the contained v0.4.6 attempt without weakening the validator.\n\n- downloads the draft receipt outside checked-out source in verifier jobs\n- makes the workflow contract reject an in-checkout receipt\n- burns unpublished v0.4.6 and advances the immutable candidate to v0.4.7\n\nMarvis task: 3d424629-af9c-43e5-9810-c78688f0727c\n\nLocal verification: 712 tests passed, 29 subtests passed, release static gate and four surface/claim validators passed on Python 3.13.