### PR TITLE
test(release): establish OSS 0.4.8 CI foundation

### DIFF
--- a/contracts/ci/collection-v1.json
+++ b/contracts/ci/collection-v1.json
@@ -54,6 +54,7 @@
         "LocalUpgradeTests.test_cli_upgrade_uses_settings_projects_root_without_environment",
         "LocalUpgradeTests.test_runtime_settings_preserve_explicit_projects_root",
         "ReleaseCandidateTests.test_real_release_candidate_is_invalidated_by_the_source_advance",
+        "ReleaseCandidateTests.test_product_projection_precedes_release_activation",
         "ReleaseCandidateTests.test_invalidated_pull_request_skips_every_expensive_release_step"
       ]
     }

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -226,6 +226,38 @@ class ReleaseCandidateTests(unittest.TestCase):
         with self.assertRaisesRegex(candidate.ReleasePolicyError, "invalidated"):
             candidate.validate_static(ROOT)
 
+    def test_product_projection_precedes_release_activation(self) -> None:
+        policy = self.policy()
+        shared_source = candidate._shared_source_coordinates(ROOT, policy)
+        state = candidate._candidate_state(policy, shared_source=shared_source)
+        projection_merge = "b96ce42f3331321828dd7f123094b39be07765ac"
+
+        ancestry = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(ROOT),
+                "merge-base",
+                "--is-ancestor",
+                projection_merge,
+                "HEAD",
+            ],
+            capture_output=True,
+        )
+        self.assertEqual(ancestry.returncode, 0)
+        self.assertEqual(
+            shared_source["merge_sha"],
+            "8dfd16e4e275b69435e0348258daf86f67898997",
+        )
+        if state["status"] == "invalidated":
+            self.assertEqual(
+                state["invalidated_by_shared_source_sha"],
+                shared_source["merge_sha"],
+            )
+        else:
+            self.assertEqual(state["status"], "active")
+            self.assertEqual(policy["plan_b_product_base_sha"], projection_merge)
+
     def test_candidate_invalidation_cannot_name_an_unrelated_source(self) -> None:
         policy = self.policy()
         policy["candidate_state"] = {


### PR DESCRIPTION
## Summary

- prove the merged MCP security projection precedes release activation
- pin that proof in the canonical CI collection
- keep the 0.4.8 candidate fail-closed until a separate release-only PR binds this merge

Marvis task: 3d424629-af9c-43e5-9810-c78688f0727c

## Local verification

- 238 unittest tests
- 444 API tests
- 32 CLI tests
- CI collection, public claims and surface gates green

No tag, PyPI upload, deploy, or manual Actions run is performed by this PR.