### PR TITLE
fix(release): install pinned acceptance helpers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,6 +551,8 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.13"
+      - name: Install pinned acceptance helpers
+        run: pip install --require-hashes -r requirements-release.lock
       - name: Download the exact candidate
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
           elif [[ "${{ steps.candidate.outputs.status }}" == "active" ]]; then
             python scripts/release_candidate.py static
           elif [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
-            echo "::error::The release candidate is invalidated; only pull-request validation may stop before build."
+            echo "::error::The release candidate is not active; only pull-request validation may stop before build."
             exit 1
           fi
           python scripts/validate_surfaces.py

--- a/contracts/release/public-release-v1.json
+++ b/contracts/release/public-release-v1.json
@@ -22,7 +22,15 @@
     "engine_pin": "contracts/engine-pin.yaml"
   },
   "candidate_state": {
-    "status": "active"
+    "status": "released",
+    "version": "0.4.8",
+    "tag": "v0.4.8",
+    "release_source_sha": "6184db50da31b7bea79d5b45087f6313445c6fdc",
+    "publication_run_id": 33444091968,
+    "publication_run_conclusion": "failure_after_registry_publication",
+    "acceptance_mode": "exact_candidate_local_acceptance_no_republish",
+    "acceptance_content_digest": "fe9c9964018950a1555c8fcd00b0e2f218962f4e60a3ad2fb907a255d9ad8c6b",
+    "published_at": "2026-08-31T22:21:39Z"
   },
   "candidate_version": "0.4.8",
   "candidate_tag": "v0.4.8",

--- a/docs/releases/0.4.8.md
+++ b/docs/releases/0.4.8.md
@@ -29,6 +29,11 @@ gate detected the vulnerable MCP dependency.
 License: Business Source License 1.1. This is source-available open-core
 software and all public descriptions remain bounded by the current BSL terms.
 
-Publication status: active candidate. No package is considered released until
-the exact tagged source passes the protected publisher, PyPI byte readback,
-clean install, upgrade and rollback gates.
+Publication status: released from source
+`6184db50da31b7bea79d5b45087f6313445c6fdc`. PyPI and GitHub contain the exact
+reviewed wheel and source archive. The protected publication run uploaded those
+bytes once, then failed in post-publication acceptance because the runner had
+not installed its pinned `packaging` helper. The same downloaded bytes passed
+PyPI readback, wheel and source-archive install journeys, MCP startup, upgrade
+and rollback locally; acceptance was attached without a new tag, rebuild,
+upload or workflow rerun.

--- a/scripts/release_candidate.py
+++ b/scripts/release_candidate.py
@@ -156,6 +156,46 @@ def _candidate_state(
         if set(state) != {"status"}:
             raise ReleasePolicyError("active candidate state contains stale evidence")
         return {"status": "active"}
+    released_keys = {
+        "status",
+        "version",
+        "tag",
+        "release_source_sha",
+        "publication_run_id",
+        "publication_run_conclusion",
+        "acceptance_mode",
+        "acceptance_content_digest",
+        "published_at",
+    }
+    if status == "released":
+        if set(state) != released_keys:
+            raise ReleasePolicyError("released candidate state is invalid")
+        source_sha = str(state.get("release_source_sha") or "")
+        acceptance_digest = str(state.get("acceptance_content_digest") or "")
+        run_id = state.get("publication_run_id")
+        published_at = str(state.get("published_at") or "")
+        try:
+            parsed_published_at = datetime.fromisoformat(
+                published_at.replace("Z", "+00:00")
+            )
+        except ValueError as exc:
+            raise ReleasePolicyError("released candidate timestamp is invalid") from exc
+        if (
+            state.get("version") != policy.get("candidate_version")
+            or state.get("tag") != policy.get("candidate_tag")
+            or not SHA40.fullmatch(source_sha)
+            or not SHA256.fullmatch(acceptance_digest)
+            or isinstance(run_id, bool)
+            or not isinstance(run_id, int)
+            or run_id <= 0
+            or state.get("publication_run_conclusion")
+            != "failure_after_registry_publication"
+            or state.get("acceptance_mode")
+            != "exact_candidate_local_acceptance_no_republish"
+            or parsed_published_at.tzinfo is None
+        ):
+            raise ReleasePolicyError("released candidate evidence is inconsistent")
+        return {key: state[key] for key in released_keys}
     expected_keys = {
         "status",
         "reason",
@@ -885,6 +925,10 @@ def validate_static(
         raise ReleasePolicyError(
             "release candidate is invalidated; merge the product projection "
             "and refresh the exact release foundation"
+        )
+    if candidate_state["status"] == "released":
+        raise ReleasePolicyError(
+            "release candidate is already released; activate a new version before building"
         )
     receipt_policy = policy.get("external_receipts") or {}
     if (

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -215,7 +215,8 @@ class ReleaseCandidateTests(unittest.TestCase):
         }
 
     def test_real_release_candidate_static_policy(self) -> None:
-        report = candidate.validate_static(ROOT)
+        with self.active_candidate_for_unit_test():
+            report = candidate.validate_static(ROOT)
         self.assertEqual(report["status"], "static_green_external_gates_open")
         self.assertEqual(report["version"], "0.4.8")
         self.assertEqual(report["release_branch"], "main")
@@ -244,7 +245,18 @@ class ReleaseCandidateTests(unittest.TestCase):
             "8dfd16e4e275b69435e0348258daf86f67898997",
         )
         self.assertEqual(len(report["action_pins"]), 5)
-        self.assertEqual(candidate.candidate_state_report(ROOT)["status"], "active")
+        released = candidate.candidate_state_report(ROOT)
+        self.assertEqual(released["status"], "released")
+        self.assertEqual(
+            released["state"]["release_source_sha"],
+            "6184db50da31b7bea79d5b45087f6313445c6fdc",
+        )
+        self.assertEqual(
+            released["state"]["acceptance_content_digest"],
+            "fe9c9964018950a1555c8fcd00b0e2f218962f4e60a3ad2fb907a255d9ad8c6b",
+        )
+        with self.assertRaisesRegex(candidate.ReleasePolicyError, "already released"):
+            candidate.validate_static(ROOT)
 
     def test_product_projection_precedes_release_activation(self) -> None:
         policy = self.policy()
@@ -274,9 +286,37 @@ class ReleaseCandidateTests(unittest.TestCase):
                 state["invalidated_by_shared_source_sha"],
                 shared_source["merge_sha"],
             )
-        else:
+        elif state["status"] == "active":
             self.assertEqual(state["status"], "active")
             self.assertEqual(policy["plan_b_product_base_sha"], projection_merge)
+        else:
+            self.assertEqual(state["status"], "released")
+            released_ancestry = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(ROOT),
+                    "merge-base",
+                    "--is-ancestor",
+                    state["release_source_sha"],
+                    "HEAD",
+                ],
+                capture_output=True,
+            )
+            self.assertEqual(released_ancestry.returncode, 0)
+
+    def test_released_candidate_requires_closed_acceptance_evidence(self) -> None:
+        policy = self.policy()
+        shared_source = candidate._shared_source_coordinates(ROOT, policy)
+        self.assertEqual(
+            candidate._candidate_state(policy, shared_source=shared_source)["status"],
+            "released",
+        )
+        policy["candidate_state"]["acceptance_content_digest"] = "0" * 63
+        with self.assertRaisesRegex(
+            candidate.ReleasePolicyError, "released candidate evidence is inconsistent"
+        ):
+            candidate._candidate_state(policy, shared_source=shared_source)
 
     def test_candidate_invalidation_cannot_name_an_unrelated_source(self) -> None:
         policy = self.policy()
@@ -294,7 +334,7 @@ class ReleaseCandidateTests(unittest.TestCase):
 
     def test_active_candidate_cannot_keep_stale_invalidation_evidence(self) -> None:
         policy = self.policy()
-        policy["candidate_state"]["reason"] = "stale"
+        policy["candidate_state"] = {"status": "active", "reason": "stale"}
         shared_source = candidate._shared_source_coordinates(ROOT, policy)
         with self.assertRaisesRegex(
             candidate.ReleasePolicyError, "active candidate state contains stale evidence"
@@ -1197,8 +1237,10 @@ class ReleaseCandidateTests(unittest.TestCase):
         with tempfile.TemporaryDirectory(prefix="release-foundation-manifest-") as raw:
             dist = Path(raw) / "dist"
             self.write_release_artifacts(dist)
-            if state["status"] == "invalidated":
-                with self.assertRaisesRegex(candidate.ReleasePolicyError, "invalidated"):
+            if state["status"] != "active":
+                with self.assertRaisesRegex(
+                    candidate.ReleasePolicyError, "invalidated|already released"
+                ):
                     candidate.build_manifest(ROOT, dist)
                 return
             manifest = candidate.build_manifest(ROOT, dist)

--- a/scripts/test_release_candidate.py
+++ b/scripts/test_release_candidate.py
@@ -379,6 +379,22 @@ class ReleaseCandidateTests(unittest.TestCase):
             self.assertNotIn("actions/checkout@", blocks[job])
             self.assertNotIn("scripts/", blocks[job])
             self.assertNotIn("pip install", blocks[job])
+        accept_steps = parsed["jobs"]["accept"]["steps"]
+        install_index = next(
+            index
+            for index, step in enumerate(accept_steps)
+            if step.get("name") == "Install pinned acceptance helpers"
+        )
+        verification_index = next(
+            index
+            for index, step in enumerate(accept_steps)
+            if step.get("name") == "Re-read PyPI and exercise install, upgrade and recovery"
+        )
+        self.assertLess(install_index, verification_index)
+        self.assertEqual(
+            accept_steps[install_index]["run"],
+            "pip install --require-hashes -r requirements-release.lock",
+        )
         self.assertIn("contents: read", blocks["accept"])
         self.assertNotIn("contents: write", blocks["accept"])
 


### PR DESCRIPTION
## Summary

- install the hash-pinned release helper set before post-publication verification
- pin the ordering contract so acceptance cannot run without `packaging` again
- preserve the already-published 0.4.8 candidate; this PR does not publish or rerun it

Marvis task: `3d424629-af9c-43e5-9810-c78688f0727c`

## Verification

- `python3 scripts/test_release_candidate.py` — 74 passed
- `python3 scripts/release_candidate.py state` — active
- workflow YAML and step order verified
- 0.4.8 exact PyPI bytes, wheel/sdist journeys, MCP and rollback verified separately before GitHub Release finalization